### PR TITLE
Fix typo causing runtime panic in getBoolean

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -295,7 +295,7 @@ func GetBoolean(data []byte, keys ...string) (val bool, offset int, err error) {
 		return false, offset, fmt.Errorf("Value is not a boolean: %s", string(v))
 	}
 
-	if v['0'] == 't' {
+	if v[0] == 't' {
 		val = true
 	} else {
 		val = false

--- a/parser_test.go
+++ b/parser_test.go
@@ -48,9 +48,25 @@ func TestValidJSON(t *testing.T) {
 		t.Errorf("Should read numberic value as number", v)
 	}
 
-    if v, _, _ := GetNumber([]byte("{\"a\": \"b\", \"c\": 1 \n}"), "c"); v != 1 {
-        t.Errorf("Should read numberic values in formatted json", v)
-    }
+	if v, _, _ := GetNumber([]byte("{\"a\": \"b\", \"c\": 1 \n}"), "c"); v != 1 {
+		t.Errorf("Should read numberic values in formatted json", v)
+	}
+
+	if v, _, _ := GetBoolean([]byte(`{"a": "b", "c": true}`), "c"); !v {
+		t.Errorf("Should read boolean true as boolean", v)
+	}
+
+	if v, _, _ := GetBoolean([]byte("{\"a\": \"b\", \"c\": true \n}"), "c"); !v {
+		t.Errorf("Should read boolean true in formatted json", v)
+	}
+
+	if v, _, _ := GetBoolean([]byte(`{"a": "b", "c": false}`), "c"); v {
+		t.Errorf("Should read boolean false as boolean", v)
+	}
+
+	if v, _, _ := GetBoolean([]byte("{\"a\": \"b\", \"c\": false \n}"), "c"); v {
+		t.Errorf("Should read boolean false in formatted json", v)
+	}
 
 	if v, _, _, _ := Get([]byte(`{"a": { "b":{"c":"d" }}}`), "a", "b", "c"); !bytes.Equal(v, []byte("d")) {
 		t.Errorf("Should read composite key", v)


### PR DESCRIPTION
There was a typo in `getBoolean` causing a runtime panic. I've added some tests to cover that function.