### PR TITLE
Fix+test whitespace handling in a few places

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -8,6 +8,19 @@ import (
 	"strconv"
 )
 
+// Find position of next character which is not whitespace
+func skipWhitespace(data []byte) int {
+	for i, b := range data {
+		switch b {
+		case ' ', '\n', '\r', '\t':
+			continue
+		default:
+			return i
+		}
+	}
+	return -1
+}
+
 // Find position of next character which is not whitespace, ',', '}' or ']'
 func nextValue(data []byte) (offset int) {
 	for true {

--- a/parser.go
+++ b/parser.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 )
 
-// Find position of next character which is not ' ', ',', '}' or ']'
+// Find position of next character which is not whitespace, ',', '}' or ']'
 func nextValue(data []byte) (offset int) {
 	for true {
 		if len(data) == offset {

--- a/parser.go
+++ b/parser.go
@@ -103,7 +103,7 @@ func fastStringBytesEqual(a string, b []byte) bool {
 	return true
 }
 
-func searchKeys(data []byte, keys ...string) int {
+func searchKeys(data []byte, keys ...string) (int, error) {
 	curKey := keys[0]
 	keyLevel := 0
 	level := 0
@@ -120,12 +120,12 @@ func searchKeys(data []byte, keys ...string) int {
 
 			se := stringEnd(data[i:])
 			if se == -1 {
-				return -1
+				return -1, errors.New("unterminated key string")
 			}
 
 			wsSkip := skipWhitespace(data[i+se:])
 			if wsSkip == -1 {
-				return -1
+				return -1, errors.New("key string with no following colon")
 			}
 
 			if data[i+se+wsSkip] == ':' && // if string is a key, and key level match
@@ -134,9 +134,9 @@ func searchKeys(data []byte, keys ...string) int {
 				keyLevel++
 				// If we found all keys in path
 				if keyLevel == lk {
-					return i + se + wsSkip + 1
+					return i + se + wsSkip + 1, nil
 				} else {
-					curKey = keys[level-1]
+					curKey = keys[keyLevel]
 				}
 			}
 
@@ -151,7 +151,7 @@ func searchKeys(data []byte, keys ...string) int {
 			// Do not search for keys inside arrays
 			aOff := trailingBracket(data[i:], '[', ']')
 			if aOff == -1 {
-				return -1
+				return -1, errors.New("unterminated array")
 			}
 
 			i += aOff + 1
@@ -160,7 +160,7 @@ func searchKeys(data []byte, keys ...string) int {
 		}
 	}
 
-	return -1
+	return -1, nil // not found
 }
 
 // Data types available in valid JSON data.
@@ -194,8 +194,8 @@ func Get(data []byte, keys ...string) (value []byte, dataType int, offset int, e
 	}()
 
 	if len(keys) > 0 {
-		if offset = searchKeys(data, keys...); offset == -1 {
-			return nil, NotExist, -1, errors.New("Key path not found")
+		if offset, err = searchKeys(data, keys...); offset == -1 {
+			return nil, NotExist, -1, err
 		}
 	}
 
@@ -282,8 +282,8 @@ func ArrayEach(data []byte, cb func(value []byte, dataType int, offset int, err 
 	offset := 1
 
 	if len(keys) > 0 {
-		if offset = searchKeys(data, keys...); offset == -1 {
-			return errors.New("Key path not found")
+		if offset, err = searchKeys(data, keys...); offset == -1 {
+			return errors.New("Key path not found: " + err.Error())
 		}
 
 		// Go to closest value

--- a/parser_test.go
+++ b/parser_test.go
@@ -169,7 +169,7 @@ func TestTrickyJSON(t *testing.T) {
             "otherchildkey": 222
           },
           "bad key\"good key": 333,
-          "whitespace"`+ ws +`:`+ ws +`333`+ ws +`,`+ ws +`
+          "whitespace"` + ws + `:` + ws + `333` + ws + `,` + ws + `
         }`)
 
 	if data, jtype, _, _ := Get(killer, "childkey"); jtype != NotExist {

--- a/parser_test.go
+++ b/parser_test.go
@@ -120,6 +120,20 @@ var getTests = []GetTest{
 		isFound: true,
 		data:    "333",
 	},
+	GetTest{
+		desc:    `escaped backslash quote`,
+		json:    `{"a": "\\\""}`,
+		path:    []string{"a"},
+		isFound: true,
+		data:    `\\\"`,
+	},
+	GetTest{
+		desc:    `unicode in JSON`,
+		json:    `{"a": "15°C"}`,
+		path:    []string{"a"},
+		isFound: true,
+		data:    `15°C`,
+	},
 
 	// Not found key tests
 	GetTest{
@@ -264,6 +278,18 @@ var getBoolTests = []GetTest{
 		isFound: true,
 		data:    false,
 	},
+	GetTest{
+		desc:  `read fake boolean true`,
+		json:  `{"a": txyz}`,
+		path:  []string{"a"},
+		isErr: true,
+	},
+	GetTest{
+		desc:  `read fake boolean false`,
+		json:  `{"a": fwxyz}`,
+		path:  []string{"a"},
+		isErr: true,
+	},
 }
 
 var getSliceTests = []GetTest{
@@ -366,7 +392,7 @@ func TestGetBool(t *testing.T) {
 	for _, gnt := range getBoolTests {
 		v, _, err := GetBoolean([]byte(gnt.json), gnt.path...)
 
-		if checkFoundAndNoError(t, "GetBoolean()", gnt, Number, err) {
+		if checkFoundAndNoError(t, "GetBoolean()", gnt, Boolean, err) {
 			if gnt.data == nil {
 				t.Errorf("MALFORMED TEST: %v", gnt)
 				continue

--- a/parser_test.go
+++ b/parser_test.go
@@ -160,6 +160,7 @@ func TestInvalidJSON(t *testing.T) {
 }
 
 func TestTrickyJSON(t *testing.T) {
+	whitespace := " \t\r\n"
 	killer := []byte(`{
           "parentkey": {
             "childkey": {
@@ -168,6 +169,7 @@ func TestTrickyJSON(t *testing.T) {
             "otherchildkey": 222
           },
           "bad key\"good key": 333,
+          `+whitespace+`
         }`)
 
 	if data, jtype, _, _ := Get(killer, "childkey"); jtype != NotExist {

--- a/parser_test.go
+++ b/parser_test.go
@@ -160,7 +160,7 @@ func TestInvalidJSON(t *testing.T) {
 }
 
 func TestTrickyJSON(t *testing.T) {
-	whitespace := " \t\r\n"
+	ws := " \t\r\n"
 	killer := []byte(`{
           "parentkey": {
             "childkey": {
@@ -169,7 +169,7 @@ func TestTrickyJSON(t *testing.T) {
             "otherchildkey": 222
           },
           "bad key\"good key": 333,
-          `+whitespace+`
+          "whitespace"`+ ws +`:`+ ws +`333`+ ws +`,`+ ws +`
         }`)
 
 	if data, jtype, _, _ := Get(killer, "childkey"); jtype != NotExist {
@@ -182,5 +182,9 @@ func TestTrickyJSON(t *testing.T) {
 
 	if data, jtype, _, _ := Get(killer, "good key"); jtype != NotExist {
 		t.Errorf(`Get("good key") should not exist, but found data %s`, string(data))
+	}
+
+	if data, jtype, _, _ := Get(killer, "whitespace"); jtype == NotExist {
+		t.Errorf(`Get("whitespace") should exist, but not found`, string(data))
 	}
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -15,176 +15,392 @@ func toArray(data []byte) (result [][]byte) {
 	return
 }
 
-func TestValidJSON(t *testing.T) {
-	if v, _, _, err := Get([]byte(`{"a":[{"b":1},{"b":2},3],"c":{"c":[1,2]}} }`), "c", "c"); !bytes.Equal(v, []byte(`[1,2]`)) {
-		t.Errorf("Should handle multiple nested keys with same name: %s, %v", string(v), err)
-	}
+func toStringArray(data []byte) (result []string) {
+	ArrayEach(data, func(value []byte, dataType int, offset int, err error) {
+		result = append(result, string(value))
+	})
 
-	if v, _, _, e := Get([]byte(`{"a":"b"}`), "a"); !bytes.Equal(v, []byte("b")) {
-		t.Errorf("Should read basic key %s %v", string(v), e)
-	}
+	return
+}
 
-	if v, _, _, _ := Get([]byte(`{"a": "b"}`), "a"); !bytes.Equal(v, []byte("b")) {
-		t.Errorf("Should read basic key with space %s", string(v))
-	}
+type GetTest struct {
+	desc string
+	json string
+	path []string
 
-	if v, _, _, _ := Get([]byte(`{"a": { "b":{"c":"d" }}}`), "a", "b", "c"); !bytes.Equal(v, []byte("d")) {
-		t.Errorf("Should read composite key %s", string(v))
-	}
+	isErr   bool
+	isFound bool
 
-	if v, _, _, err := Get([]byte(`{"a": { "b": 1}, "c": 2 }`), "a", "b", "c"); err == nil {
-		t.Errorf("Should apply scope of parent when search for nested key: %s, %v", string(v), err)
-	}
+	data interface{}
+}
 
-	if v, _, _, err := Get([]byte(`{"a": { "b": 1}, "c": 2 }`), "b"); err == nil {
-		t.Errorf("Should apply scope to key level: %s, %v", string(v), err)
-	}
+var getTests = []GetTest{
+	// Found key tests
+	GetTest{
+		desc:    "handling multiple nested keys with same name",
+		json:    `{"a":[{"b":1},{"b":2},3],"c":{"c":[1,2]}} }`,
+		path:    []string{"c", "c"},
+		isFound: true,
+		data:    `[1,2]`,
+	},
+	GetTest{
+		desc:    "read basic key",
+		json:    `{"a":"b"}`,
+		path:    []string{"a"},
+		isFound: true,
+		data:    `b`,
+	},
+	GetTest{
+		desc:    "read basic key with space",
+		json:    `{"a": "b"}`,
+		path:    []string{"a"},
+		isFound: true,
+		data:    `b`,
+	},
+	GetTest{
+		desc:    "read composite key",
+		json:    `{"a": { "b":{"c":"d" }}}`,
+		path:    []string{"a", "b", "c"},
+		isFound: true,
+		data:    `d`,
+	},
+	GetTest{
+		desc:    `read numberic value as string`,
+		json:    `{"a": "b", "c": 1}`,
+		path:    []string{"c"},
+		isFound: true,
+		data:    `1`,
+	},
+	GetTest{
+		desc:    `handle multiple nested keys with same name`,
+		json:    `{"a":[{"b":1},{"b":2},3],"c":{"c":[1,2]}} }`,
+		path:    []string{"c", "c"},
+		isFound: true,
+		data:    `[1,2]`,
+	},
+	GetTest{
+		desc:    `read string values with quotes`,
+		json:    `{"a": "string\"with\"quotes"}`,
+		path:    []string{"a"},
+		isFound: true,
+		data:    `string\"with\"quotes`,
+	},
+	GetTest{
+		desc:    `read object`,
+		json:    `{"a": { "b":{"c":"d" }}}`,
+		path:    []string{"a", "b"},
+		isFound: true,
+		data:    `{"c":"d" }`,
+	},
+	GetTest{
+		desc:    `empty path`,
+		json:    `{"c":"d" }`,
+		path:    []string{},
+		isFound: true,
+		data:    `{"c":"d" }`,
+	},
+	GetTest{
+		desc:    `formatted JSON value`,
+		json:    "{\n  \"a\": \"b\"\n}",
+		path:    []string{"a"},
+		isFound: true,
+		data:    `b`,
+	},
+	GetTest{
+		desc:    `formatted JSON value 2`,
+		json:    "{\n  \"a\":\n    {\n\"b\":\n   {\"c\":\"d\",\n\"e\": \"f\"}\n}\n}",
+		path:    []string{"a", "b"},
+		isFound: true,
+		data:    "{\"c\":\"d\",\n\"e\": \"f\"}",
+	},
+	GetTest{
+		desc:    `whitespace`,
+		json:    " \n\r\t{ \n\r\t\"whitespace\" \n\r\t: \n\r\t333 \n\r\t} \n\r\t",
+		path:    []string{"whitespace"},
+		isFound: true,
+		data:    "333",
+	},
 
-	if v, _, _, _ := Get([]byte(`{"a": "b", "c": 1}`), "c"); !bytes.Equal(v, []byte("1")) {
-		t.Errorf("Should read numberic value as string %s", string(v))
-	}
+	// Not found key tests
+	GetTest{
+		desc:    "non-existent key 1",
+		json:    `{"a":"b"}`,
+		path:    []string{"c"},
+		isFound: false,
+	},
+	GetTest{
+		desc:    "non-existent key 2",
+		json:    `{"a":"b"}`,
+		path:    []string{"b"},
+		isFound: false,
+	},
+	GetTest{
+		desc:    "non-existent key 3",
+		json:    `{"aa":"b"}`,
+		path:    []string{"a"},
+		isFound: false,
+	},
+	GetTest{
+		desc:    "apply scope of parent when search for nested key",
+		json:    `{"a": { "b": 1}, "c": 2 }`,
+		path:    []string{"a", "b", "c"},
+		isFound: false,
+	},
+	GetTest{
+		desc:    `apply scope to key level`,
+		json:    `{"a": { "b": 1}, "c": 2 }`,
+		path:    []string{"b"},
+		isFound: false,
+	},
+	GetTest{
+		desc:    `handle escaped quote in key name in JSON`,
+		json:    `{"key\"key": 1}`,
+		path:    []string{"key"},
+		isFound: false,
+	},
 
-	if v, _, _, _ := Get([]byte(`{"a": "string\"with\"quotes"}`), "a"); !bytes.Equal(v, []byte(`string\"with\"quotes`)) {
-		t.Errorf("Should read string values with quotes %s", string(v))
-	}
+	// Error/invalid tests
+	GetTest{
+		desc:    `handle escaped quote in key name in JSON`,
+		json:    `{"key\"key": 1}`,
+		path:    []string{"key"},
+		isFound: false,
+	},
+	GetTest{
+		desc:    `missing closing brace, but can still find key`,
+		json:    `{"a":"b"`,
+		path:    []string{"a"},
+		isFound: true,
+		data:    `b`,
+	},
+	GetTest{
+		desc:  `missing value closing quote`,
+		json:  `{"a":"b`,
+		path:  []string{"a"},
+		isErr: true,
+	},
+	GetTest{
+		desc:  `missing value closing curly brace`,
+		json:  `{"a": { "b": "c"`,
+		path:  []string{"a"},
+		isErr: true,
+	},
+	GetTest{
+		desc:  `missing value closing square bracket`,
+		json:  `{"a": [1, 2, 3 }`,
+		path:  []string{"a"},
+		isErr: true,
+	},
+	GetTest{
+		desc:  `missing value 1`,
+		json:  `{"a":`,
+		path:  []string{"a"},
+		isErr: true,
+	},
+	GetTest{
+		desc:  `missing value 2`,
+		json:  `{"a": `,
+		path:  []string{"a"},
+		isErr: true,
+	},
+	GetTest{
+		desc:  `missing value 3`,
+		json:  `{"a":}`,
+		path:  []string{"a"},
+		isErr: true,
+	},
+}
 
-	if v, _, _ := GetNumber([]byte(`{"a": "b", "c": 1}`), "c"); v != 1 {
-		t.Errorf("Should read numberic value as number %d", v)
-	}
+var getNumberTests = []GetTest{
+	GetTest{
+		desc:    `read numeric value as number`,
+		json:    `{"a": "b", "c": 1}`,
+		path:    []string{"c"},
+		isFound: true,
+		data:    float64(1),
+	},
+	GetTest{
+		desc:    `read numeric value as number in formatted JSON`,
+		json:    "{\"a\": \"b\", \"c\": 1 \n}",
+		path:    []string{"c"},
+		isFound: true,
+		data:    float64(1),
+	},
+	GetTest{
+		desc:    `read numeric value as number in formatted JSON`,
+		json:    "{\"a\": \"b\", \"c\": 1 \n}",
+		path:    []string{"c"},
+		isFound: true,
+		data:    float64(1),
+	},
+}
 
-	if v, _, _, err := Get([]byte(`{"a":[{"b":1},{"b":2},3],"c":{"c":[1,2]}} }`), "c", "c"); !bytes.Equal(v, []byte(`[1,2]`)) {
-		t.Errorf("Should handle multiple nested keys with same name: %s, %v", string(v), err)
-	}
+var getBoolTests = []GetTest{
+	GetTest{
+		desc:    `read boolean true as boolean`,
+		json:    `{"a": "b", "c": true}`,
+		path:    []string{"c"},
+		isFound: true,
+		data:    true,
+	},
+	GetTest{
+		desc:    `boolean true in formatted JSON`,
+		json:    "{\"a\": \"b\", \"c\": true \n}",
+		path:    []string{"c"},
+		isFound: true,
+		data:    true,
+	},
+	GetTest{
+		desc:    `read boolean false as boolean`,
+		json:    `{"a": "b", "c": false}`,
+		path:    []string{"c"},
+		isFound: true,
+		data:    false,
+	},
+	GetTest{
+		desc:    `boolean true in formatted JSON`,
+		json:    "{\"a\": \"b\", \"c\": false \n}",
+		path:    []string{"c"},
+		isFound: true,
+		data:    false,
+	},
+}
 
-	if v, _, _ := GetNumber([]byte("{\"a\": \"b\", \"c\": 1 \n}"), "c"); v != 1 {
-		t.Errorf("Should read numberic values in formatted json %d", v)
-	}
+var getSliceTests = []GetTest{
+	GetTest{
+		desc:    `read array of simple values`,
+		json:    `{"a": { "b":[1,2,3,4]}}`,
+		path:    []string{"a", "b"},
+		isFound: true,
+		data:    []string{`1`, `2`, `3`, `4`},
+	},
+	GetTest{
+		desc:    `read array via empty path`,
+		json:    `[1,2,3,4]`,
+		path:    []string{},
+		isFound: true,
+		data:    []string{`1`, `2`, `3`, `4`},
+	},
+	GetTest{
+		desc:    `read array of objects`,
+		json:    `{"a": { "b":[{"x":1},{"x":2},{"x":3},{"x":4}]}}`,
+		path:    []string{"a", "b"},
+		isFound: true,
+		data:    []string{`{"x":1}`, `{"x":2}`, `{"x":3}`, `{"x":4}`},
+	},
+	GetTest{
+		desc:    `read nested array`,
+		json:    `{"a": [[[1]],[[2]]]}`,
+		path:    []string{"a"},
+		isFound: true,
+		data:    []string{`[[1]]`, `[[2]]`},
+	},
+}
 
-	if v, _, _ := GetBoolean([]byte(`{"a": "b", "c": true}`), "c"); !v {
-		t.Errorf("Should read boolean true as boolean %v", v)
-	}
+// checkFoundAndNoError checks the dataType and error return from Get*() against the test case expectations.
+// Returns true the test should proceed to checking the actual data returned from Get*(), or false if the test is finished.
+func checkFoundAndNoError(t *testing.T, testKind string, test GetTest, jtype int, err error) bool {
+	isFound := (jtype != NotExist)
+	isErr := (err != nil)
 
-	if v, _, _ := GetBoolean([]byte("{\"a\": \"b\", \"c\": true \n}"), "c"); !v {
-		t.Errorf("Should read boolean true in formatted json %v", v)
-	}
-
-	if v, _, _ := GetBoolean([]byte(`{"a": "b", "c": false}`), "c"); v {
-		t.Errorf("Should read boolean false as boolean %v", v)
-	}
-
-	if v, _, _ := GetBoolean([]byte("{\"a\": \"b\", \"c\": false \n}"), "c"); v {
-		t.Errorf("Should read boolean false in formatted json %v", v)
-	}
-
-	if v, _, _ := GetNumber([]byte("{\"a\": \"b\", \"c\": 1 \n}"), "c"); v != 1 {
-		t.Errorf("Should read numberic values in formatted json %d", v)
-	}
-
-	if v, _, _ := GetBoolean([]byte(`{"a": "b", "c": true}`), "c"); !v {
-		t.Errorf("Should read boolean true as boolean %v", v)
-	}
-
-	if v, _, _ := GetBoolean([]byte("{\"a\": \"b\", \"c\": true \n}"), "c"); !v {
-		t.Errorf("Should read boolean true in formatted json %v", v)
-	}
-
-	if v, _, _ := GetBoolean([]byte(`{"a": "b", "c": false}`), "c"); v {
-		t.Errorf("Should read boolean false as boolean %v", v)
-	}
-
-	if v, _, _ := GetBoolean([]byte("{\"a\": \"b\", \"c\": false \n}"), "c"); v {
-		t.Errorf("Should read boolean false in formatted json %v", v)
-	}
-
-	if v, _, _, _ := Get([]byte(`{"a": { "b":{"c":"d" }}}`), "a", "b", "c"); !bytes.Equal(v, []byte("d")) {
-		t.Errorf("Should read composite key %s", string(v))
-	}
-
-	if v, _, _, _ := Get([]byte(`{"a": { "b":{"c":"d" }}}`), "a", "b"); !bytes.Equal(v, []byte(`{"c":"d" }`)) {
-		t.Errorf("Should read object %s", string(v))
-	}
-
-	if v, _, _, _ := Get([]byte(`{"c":"d" }`)); !bytes.Equal(v, []byte(`{"c":"d" }`)) {
-		t.Errorf("Should handle empty path %s", string(v))
-	}
-
-	if v, _, _, _ := Get([]byte(`{"a": { "b":[1,2,3,4]}}`), "a", "b"); !reflect.DeepEqual(toArray(v), [][]byte{[]byte("1"), []byte("2"), []byte("3"), []byte(`4`)}) {
-		t.Errorf("Should read array of simple values: %s, %v", string(v), toArray(v))
-	}
-
-	if v, _, _, _ := Get([]byte(`[1,2,3,4]`)); !reflect.DeepEqual(toArray(v), [][]byte{[]byte("1"), []byte("2"), []byte("3"), []byte(`4`)}) {
-		t.Errorf("Should parse array without specifying path: %s %v", string(v), toArray(v))
-	}
-
-	if v, _, _, _ := Get([]byte(`{"a": { "b":[{"x":1},{"x":2},{"x":3},{"x":4}]}}`), "a", "b"); !reflect.DeepEqual(toArray(v), [][]byte{[]byte(`{"x":1}`), []byte(`{"x":2}`), []byte(`{"x":3}`), []byte(`{"x":4}`)}) {
-		t.Errorf("Should read array of objects %s", string(v))
-	}
-
-	if v, _, _, _ := Get([]byte(`{"a": [[[1]],[[2]]]}`), "a"); !reflect.DeepEqual(toArray(v), [][]byte{[]byte("[[1]]"), []byte("[[2]]")}) {
-		t.Errorf("Should parse nested array %s", string(v))
-	}
-
-	if v, _, _, _ := Get([]byte("{\n  \"a\": \"b\"\n}"), "a"); !bytes.Equal(v, []byte("b")) {
-		t.Errorf("Should read formated json value %s", string(v))
-	}
-
-	if v, _, _, e := Get([]byte("{\n  \"a\":\n    {\n\"b\":\n   {\"c\":\"d\",\n\"e\": \"f\"}\n}\n}"), "a", "b"); !bytes.Equal(v, []byte("{\"c\":\"d\",\n\"e\": \"f\"}")) {
-		t.Errorf("Should read formated json object %s %v", string(v), e)
+	if test.isErr != isErr {
+		// If the call didn't match the error expectation, fail
+		t.Errorf("%s test '%s' isErr mismatch: expected %t, obtained %t (err %v)", testKind, test.desc, test.isErr, isErr, err)
+		return false
+	} else if isErr {
+		// Else, if there was an error, don't fail and don't check isFound or the value
+		return false
+	} else if test.isFound != isFound {
+		// Else, if the call didn't match the is-found expectation, fail
+		t.Errorf("%s test '%s' isFound mismatch: expected %t, obtained %t", testKind, test.desc, test.isFound, isFound)
+		return false
+	} else if !isFound {
+		// Else, if no value was found, don't fail and don't check the value
+		return false
+	} else {
+		// Else, there was no error and a value was found, so check the value
+		return true
 	}
 }
 
-func TestInvalidJSON(t *testing.T) {
-	if _, _, _, e := Get([]byte(`{"a":"b"`), "c"); e == nil || e.Error() != "Key path not found" {
-		t.Errorf("Should not found key: %v", e)
-	}
+func TestGet(t *testing.T) {
+	for _, gt := range getTests {
+		v, jtype, _, err := Get([]byte(gt.json), gt.path...)
 
-	if v, _, _, e := Get([]byte(`{"a":"b"`), "a"); !bytes.Equal(v, []byte("b")) || e != nil {
-		t.Errorf("Should not found missing bracket, because key still found: %s", string(v))
-	}
+		if checkFoundAndNoError(t, "Get()", gt, jtype, err) {
+			if gt.data == nil {
+				t.Errorf("MALFORMED TEST: %v", gt)
+				continue
+			}
 
-	if _, _, _, e := Get([]byte(`{"a":"b`), "a"); e == nil || e.Error() != "Value is string, but can't find closing '\"' symbol" {
-		t.Errorf("Should raise error since end of string not found: %v", e)
-	}
-
-	if v, _, _, e := Get([]byte(`{"a": { "b": "c"`), "a"); e == nil || e.Error() != "Value looks like object, but can't find closing '}' symbol" {
-		t.Errorf("Should raise error if closing brace not found: %v %s", e, string(v))
-	}
-
-	if v, _, _, e := Get([]byte(`{"a": [1, 2, 3 }`), "a"); e == nil || e.Error() != "Value is array, but can't find closing ']' symbol" {
-		t.Errorf("Should raise error if closing bracket not found: %v %s", e, string(v))
-	}
-
-	if _, _, _, e := Get([]byte(`{"a": `), "a"); e == nil || e.Error() != "Malformed JSON error" {
-		t.Errorf("Should raise malformed json error: %v", e)
+			expectedData := []byte(gt.data.(string))
+			if !bytes.Equal(expectedData, v) {
+				t.Errorf("Get() test '%s' expected to return value %v, but did returned %v instead", string(expectedData), string(v))
+			}
+		}
 	}
 }
 
-func TestTrickyJSON(t *testing.T) {
-	ws := " \t\r\n"
-	killer := []byte(`{
-          "parentkey": {
-            "childkey": {
-              "grandchildkey": 111
-            },
-            "otherchildkey": 222
-          },
-          "bad key\"good key": 333,
-          "whitespace"` + ws + `:` + ws + `333` + ws + `,` + ws + `
-        }`)
+func TestGetNumber(t *testing.T) {
+	for _, gnt := range getNumberTests {
+		v, _, err := GetNumber([]byte(gnt.json), gnt.path...)
 
-	if data, jtype, _, _ := Get(killer, "childkey"); jtype != NotExist {
-		t.Errorf(`Get("childkey") should not exist, but found data %s`, string(data))
+		if checkFoundAndNoError(t, "GetNumber()", gnt, Number, err) {
+			if gnt.data == nil {
+				t.Errorf("MALFORMED TEST: %v", gnt)
+				continue
+			} else if _, ok := gnt.data.(float64); !ok {
+				t.Errorf("MALFORMED TEST: %v", gnt)
+				continue
+			}
+
+			expectedData := gnt.data.(float64)
+			if expectedData != v {
+				t.Errorf("GetNumber() test '%s' expected to return value %v, but did returned %v instead", expectedData, v)
+			}
+		}
 	}
+}
 
-	if data, jtype, _, _ := Get(killer, "parentkey", "childkey", "otherchildkey"); jtype != NotExist {
-		t.Errorf(`Get("parentkey", "childkey", "otherchildkey") should not exist, but found data %s`, string(data))
+func TestGetBool(t *testing.T) {
+	for _, gnt := range getBoolTests {
+		v, _, err := GetBoolean([]byte(gnt.json), gnt.path...)
+
+		if checkFoundAndNoError(t, "GetBoolean()", gnt, Number, err) {
+			if gnt.data == nil {
+				t.Errorf("MALFORMED TEST: %v", gnt)
+				continue
+			} else if _, ok := gnt.data.(bool); !ok {
+				t.Errorf("MALFORMED TEST: %v", gnt)
+				continue
+			}
+
+			expectedData := gnt.data.(bool)
+			if expectedData != v {
+				t.Errorf("GetBoolean() test '%s' expected to return value %v, but did returned %v instead", expectedData, v)
+			}
+		}
 	}
+}
 
-	if data, jtype, _, _ := Get(killer, "good key"); jtype != NotExist {
-		t.Errorf(`Get("good key") should not exist, but found data %s`, string(data))
-	}
+func TestGetSlice(t *testing.T) {
+	for _, gst := range getSliceTests {
+		v, jtype, _, err := Get([]byte(gst.json), gst.path...)
 
-	if data, jtype, _, _ := Get(killer, "whitespace"); jtype == NotExist {
-		t.Errorf(`Get("whitespace") should exist, but not found`, string(data))
+		if checkFoundAndNoError(t, "Get()", gst, jtype, err) {
+			if gst.data == nil {
+				t.Errorf("MALFORMED TEST: %v", gst)
+				continue
+			} else if _, ok := gst.data.([]string); !ok {
+				t.Errorf("MALFORMED TEST: %v", gst)
+				continue
+			}
+
+			expectedData := gst.data.([]string)
+			vslice := toStringArray(v)
+			if !reflect.DeepEqual(expectedData, vslice) {
+				t.Errorf("Get() test '%s' expected to return value %v, but did returned %v instead", expectedData, v)
+			}
+		}
 	}
 }


### PR DESCRIPTION
Tests and fixes whitespace handling in the parser.

The first issue is that the parser assumes a colon will immediately follow a key string, and does not permit whitespace there. This fix skips any whitespace after a key until it finds the colon.

The second issue is that the parser does not understand carriage returns or tabs anywhere in the input. Fixed that as well.
