### PR TITLE
Support for unicode and escaped symbols and some API changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,21 @@ Returns:
 Accepts multiple keys to specify path to JSON value (in case of quering nested structures).
 If no keys are provided it will try to extract the closest JSON value (simple ones or object/array), useful for reading streams or arrays, see `ArrayEach` implementation.
 
+### **`GetString`**
+```
+func GetString(data []byte, keys ...string) (val string, err error)
+```
+Returns strings properly handing escaped and unicode characters. Note that this will cause additioal memory allocations.
+
 ### **`GetBoolean`**, **`GetInt`** and **`GetFloat`**
 ```
-func GetBoolean(data []byte, keys ...string) (val bool, offset int, err error)
+func GetBoolean(data []byte, keys ...string) (val bool, err error)
 
-func GetFloat(data []byte, keys ...string) (val float64, offset int, err error)
+func GetFloat(data []byte, keys ...string) (val float64, err error)
 
-func GetInt(data []byte, keys ...string) (val float64, offset int, err error)
+func GetInt(data []byte, keys ...string) (val float64, err error)
 ```
-If you know the key type, you can use the helpers above. Returns same arguments as `Get` except `dataType`.
+If you know the key type, you can use the helpers above.
 If key data type do not match, it will return error.
 
 ### **`ArrayEach`**

--- a/README.md
+++ b/README.md
@@ -86,6 +86,21 @@ func GetString(data []byte, keys ...string) (val string, err error)
 ```
 Returns strings properly handing escaped and unicode characters. Note that this will cause additioal memory allocations.
 
+### **`UnsafeBytesToString`**
+If you need string in your app, and ready to sacrifice with support of escaped symbols in favor of speed, you may use `UnsafeBytesToString` method, which returns string mapped to exsting byte slice memory, without any allocations:
+```go
+v, _, _, _ := jsonparser.Get(data, "person", "name", "title")
+switch jsonparser.UnsafeBytesToString(v) {
+  case 'CEO':
+    ...
+  case 'Engineer'
+    ...
+  ...
+}
+```
+Note that `unsafe` here means that your string will exist until GC will free unrelying byte slice, for most of cases it means that you can use this string only in current context, and should not pass it anywhere externally: through channels or any other way.
+
+
 ### **`GetBoolean`**, **`GetInt`** and **`GetFloat`**
 ```
 func GetBoolean(data []byte, keys ...string) (val bool, err error)

--- a/parser.go
+++ b/parser.go
@@ -98,8 +98,6 @@ func searchKeys(data []byte, keys ...string) int {
 			return -1
 		}
 
-		c := data[i]
-
 		switch data[i] {
 		case '"':
 			i++
@@ -315,6 +313,29 @@ func ArrayEach(data []byte, cb func(value []byte, dataType int, offset int, err 
 	}
 
 	return nil
+}
+
+// GetString returns the value retrieved by `Get`, cast to a string if possible, trying to properly handle escape and utf8 symbols
+// If key data type do not match, it will return an error.
+func GetString(data []byte, keys ...string) (val string, offset int, err error) {
+	v, t, offset, e := Get(data, keys...)
+
+	if e != nil {
+		return "", offset, e
+	}
+
+	if t != String {
+		return "", offset, fmt.Errorf("Value is not a number: %s", string(v))
+	}
+
+	// If no escapes return raw conten
+	if bytes.IndexByte(v, '\\') == -1 {
+		return string(v), offset, nil
+	}
+
+	s, err := strconv.Unquote(`"` + bytesToString(v) + `"`)
+
+	return s, offset, err
 }
 
 // GetFloat returns the value retrieved by `Get`, cast to a float64 if possible.

--- a/parser.go
+++ b/parser.go
@@ -120,7 +120,7 @@ func searchKeys(data []byte, keys ...string) int {
 				// Checks to speedup key comparsion
 				len(keys[level-1]) == se-1 && // if it have same length
 				data[i] == keys[level-1][0] { // If first character same
-				if keys[level-1] == bytesToString(data[i:i+se-1]) {
+				if keys[level-1] == UnsafeBytesToString(data[i:i+se-1]) {
 					keyLevel++
 					// If we found all keys in path
 					if keyLevel == lk {
@@ -227,7 +227,7 @@ func Get(data []byte, keys ...string) (value []byte, dataType int, offset int, e
 			return nil, dataType, offset, errors.New("Value looks like Number/Boolean/None, but can't find its end: ',' or '}' symbol")
 		}
 
-		value := bytesToString(data[offset : endOffset+end])
+		value := UnsafeBytesToString(data[offset : endOffset+end])
 
 		switch data[offset] {
 		case 't', 'f': // true or false
@@ -333,7 +333,7 @@ func GetString(data []byte, keys ...string) (val string, err error) {
 		return string(v), nil
 	}
 
-	s, err := strconv.Unquote(`"` + bytesToString(v) + `"`)
+	s, err := strconv.Unquote(`"` + UnsafeBytesToString(v) + `"`)
 
 	return s, err
 }
@@ -352,7 +352,7 @@ func GetFloat(data []byte, keys ...string) (val float64, err error) {
 		return 0, fmt.Errorf("Value is not a number: %s", string(v))
 	}
 
-	val, err = strconv.ParseFloat(bytesToString(v), 64)
+	val, err = strconv.ParseFloat(UnsafeBytesToString(v), 64)
 	return
 }
 
@@ -369,7 +369,7 @@ func GetInt(data []byte, keys ...string) (val int64, err error) {
 		return 0, fmt.Errorf("Value is not a number: %s", string(v))
 	}
 
-	val, err = strconv.ParseInt(bytesToString(v), 10, 64)
+	val, err = strconv.ParseInt(UnsafeBytesToString(v), 10, 64)
 	return
 }
 
@@ -398,7 +398,7 @@ func GetBoolean(data []byte, keys ...string) (val bool, err error) {
 
 // A hack until issue golang/go#2632 is fixed.
 // See: https://github.com/golang/go/issues/2632
-func bytesToString(data []byte) string {
+func UnsafeBytesToString(data []byte) string {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&data))
 	sh := reflect.StringHeader{Data: h.Data, Len: h.Len}
 	return *(*string)(unsafe.Pointer(&sh))

--- a/parser.go
+++ b/parser.go
@@ -317,39 +317,39 @@ func ArrayEach(data []byte, cb func(value []byte, dataType int, offset int, err 
 
 // GetString returns the value retrieved by `Get`, cast to a string if possible, trying to properly handle escape and utf8 symbols
 // If key data type do not match, it will return an error.
-func GetString(data []byte, keys ...string) (val string, offset int, err error) {
-	v, t, offset, e := Get(data, keys...)
+func GetString(data []byte, keys ...string) (val string, err error) {
+	v, t, _, e := Get(data, keys...)
 
 	if e != nil {
-		return "", offset, e
+		return "", e
 	}
 
 	if t != String {
-		return "", offset, fmt.Errorf("Value is not a number: %s", string(v))
+		return "", fmt.Errorf("Value is not a number: %s", string(v))
 	}
 
 	// If no escapes return raw conten
 	if bytes.IndexByte(v, '\\') == -1 {
-		return string(v), offset, nil
+		return string(v), nil
 	}
 
 	s, err := strconv.Unquote(`"` + bytesToString(v) + `"`)
 
-	return s, offset, err
+	return s, err
 }
 
 // GetFloat returns the value retrieved by `Get`, cast to a float64 if possible.
 // The offset is the same as in `Get`.
 // If key data type do not match, it will return an error.
-func GetFloat(data []byte, keys ...string) (val float64, offset int, err error) {
-	v, t, offset, e := Get(data, keys...)
+func GetFloat(data []byte, keys ...string) (val float64, err error) {
+	v, t, _, e := Get(data, keys...)
 
 	if e != nil {
-		return 0, offset, e
+		return 0, e
 	}
 
 	if t != Number {
-		return 0, offset, fmt.Errorf("Value is not a number: %s", string(v))
+		return 0, fmt.Errorf("Value is not a number: %s", string(v))
 	}
 
 	val, err = strconv.ParseFloat(bytesToString(v), 64)
@@ -357,17 +357,16 @@ func GetFloat(data []byte, keys ...string) (val float64, offset int, err error) 
 }
 
 // GetInt returns the value retrieved by `Get`, cast to a float64 if possible.
-// The offset is the same as in `Get`.
 // If key data type do not match, it will return an error.
-func GetInt(data []byte, keys ...string) (val int64, offset int, err error) {
-	v, t, offset, e := Get(data, keys...)
+func GetInt(data []byte, keys ...string) (val int64, err error) {
+	v, t, _, e := Get(data, keys...)
 
 	if e != nil {
-		return 0, offset, e
+		return 0, e
 	}
 
 	if t != Number {
-		return 0, offset, fmt.Errorf("Value is not a number: %s", string(v))
+		return 0, fmt.Errorf("Value is not a number: %s", string(v))
 	}
 
 	val, err = strconv.ParseInt(bytesToString(v), 10, 64)
@@ -377,15 +376,15 @@ func GetInt(data []byte, keys ...string) (val int64, offset int, err error) {
 // GetBoolean returns the value retrieved by `Get`, cast to a bool if possible.
 // The offset is the same as in `Get`.
 // If key data type do not match, it will return error.
-func GetBoolean(data []byte, keys ...string) (val bool, offset int, err error) {
-	v, t, offset, e := Get(data, keys...)
+func GetBoolean(data []byte, keys ...string) (val bool, err error) {
+	v, t, _, e := Get(data, keys...)
 
 	if e != nil {
-		return false, offset, e
+		return false, e
 	}
 
 	if t != Boolean {
-		return false, offset, fmt.Errorf("Value is not a boolean: %s", string(v))
+		return false, fmt.Errorf("Value is not a boolean: %s", string(v))
 	}
 
 	if v[0] == 't' {

--- a/parser_test.go
+++ b/parser_test.go
@@ -423,7 +423,7 @@ func TestGet(t *testing.T) {
 func TestGetString(t *testing.T) {
 	runTests(t, getStringTests,
 		func(test Test) (value interface{}, dataType int, err error) {
-			value, _, err = GetString([]byte(test.json), test.path...)
+			value, err = GetString([]byte(test.json), test.path...)
 			return value, String, err
 		},
 		func(test Test, value interface{}) (bool, interface{}) {
@@ -436,7 +436,7 @@ func TestGetString(t *testing.T) {
 func TestGetInt(t *testing.T) {
 	runTests(t, getIntTests,
 		func(test Test) (value interface{}, dataType int, err error) {
-			value, _, err = GetInt([]byte(test.json), test.path...)
+			value, err = GetInt([]byte(test.json), test.path...)
 			return value, Number, err
 		},
 		func(test Test, value interface{}) (bool, interface{}) {
@@ -449,7 +449,7 @@ func TestGetInt(t *testing.T) {
 func TestGetFloat(t *testing.T) {
 	runTests(t, getFloatTests,
 		func(test Test) (value interface{}, dataType int, err error) {
-			value, _, err = GetFloat([]byte(test.json), test.path...)
+			value, err = GetFloat([]byte(test.json), test.path...)
 			return value, Number, err
 		},
 		func(test Test, value interface{}) (bool, interface{}) {
@@ -462,7 +462,7 @@ func TestGetFloat(t *testing.T) {
 func TestGetBoolean(t *testing.T) {
 	runTests(t, getBoolTests,
 		func(test Test) (value interface{}, dataType int, err error) {
-			value, _, err = GetBoolean([]byte(test.json), test.path...)
+			value, err = GetBoolean([]byte(test.json), test.path...)
 			return value, Boolean, err
 		},
 		func(test Test, value interface{}) (bool, interface{}) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -266,6 +266,30 @@ var getFloatTests = []Test{
 	},
 }
 
+var getStringTests = []Test{
+	Test{
+		desc:    `Translate unicode symbols`,
+		json:    `{"c": "test"}`,
+		path:    []string{"c"},
+		isFound: true,
+		data:    `test`,
+	},
+	Test{
+		desc:    `Translate unicode symbols`,
+		json:    `{"c": "15\u00b0C"}`,
+		path:    []string{"c"},
+		isFound: true,
+		data:    `15°C`,
+	},
+	Test{
+		desc:    `Translate escape symbols`,
+		json:    `{"c": "\\\""}`,
+		path:    []string{"c"},
+		isFound: true,
+		data:    `\"`,
+	},
+}
+
 var getBoolTests = []Test{
 	Test{
 		desc:    `read boolean true as boolean`,
@@ -368,10 +392,6 @@ func checkFoundAndNoError(t *testing.T, testKind string, test Test, jtype int, v
 
 func runTests(t *testing.T, tests []Test, runner func(Test) (interface{}, int, error), typeChecker func(Test, interface{}) (bool, interface{})) {
 	for _, test := range tests {
-		if test.desc != "whitespace" {
-			continue
-		}
-
 		value, dataType, err := runner(test)
 
 		if checkFoundAndNoError(t, "Get()", test, dataType, value, err) {
@@ -400,11 +420,24 @@ func TestGet(t *testing.T) {
 	)
 }
 
+func TestGetString(t *testing.T) {
+	runTests(t, getStringTests,
+		func(test Test) (value interface{}, dataType int, err error) {
+			value, _, err = GetString([]byte(test.json), test.path...)
+			return value, String, err
+		},
+		func(test Test, value interface{}) (bool, interface{}) {
+			expected := test.data.(string)
+			return expected == value.(string), expected
+		},
+	)
+}
+
 func TestGetInt(t *testing.T) {
 	runTests(t, getIntTests,
 		func(test Test) (value interface{}, dataType int, err error) {
-			value, dataType, err = GetInt([]byte(test.json), test.path...)
-			return
+			value, _, err = GetInt([]byte(test.json), test.path...)
+			return value, Number, err
 		},
 		func(test Test, value interface{}) (bool, interface{}) {
 			expected := test.data.(int64)
@@ -416,8 +449,8 @@ func TestGetInt(t *testing.T) {
 func TestGetFloat(t *testing.T) {
 	runTests(t, getFloatTests,
 		func(test Test) (value interface{}, dataType int, err error) {
-			value, dataType, err = GetFloat([]byte(test.json), test.path...)
-			return
+			value, _, err = GetFloat([]byte(test.json), test.path...)
+			return value, Number, err
 		},
 		func(test Test, value interface{}) (bool, interface{}) {
 			expected := test.data.(float64)
@@ -429,8 +462,8 @@ func TestGetFloat(t *testing.T) {
 func TestGetBoolean(t *testing.T) {
 	runTests(t, getBoolTests,
 		func(test Test) (value interface{}, dataType int, err error) {
-			value, dataType, err = GetBoolean([]byte(test.json), test.path...)
-			return
+			value, _, err = GetBoolean([]byte(test.json), test.path...)
+			return value, Boolean, err
 		},
 		func(test Test, value interface{}) (bool, interface{}) {
 			expected := test.data.(bool)


### PR DESCRIPTION
* Added `GetString` method which does proper unicode and escape symbols handling. Note that it will cause additional memory allocations. Currently it use built-in go function, but i guess its not really fast.
* All `Get[Type]` function now return only 2 arguments, value and error.
* `UnsafeBytesToString` now public function, and added docs how to use it.
