### PR TITLE
Faster+safer use of unsafe package + non-unsafe fallback implementations

### DIFF
--- a/fastbytes.go
+++ b/fastbytes.go
@@ -1,0 +1,27 @@
+package jsonparser
+
+func BytesParseInt(bytes []byte) (v int64, ok bool) {
+	if len(bytes) == 0 {
+		return 0, false
+	}
+
+	var neg bool = false
+	if bytes[0] == '-' {
+		neg = true
+		bytes = bytes[1:]
+	}
+
+	for _, c := range bytes {
+		if c >= '0' && c <= '9' {
+			v = (10 * v) + int64(c-'0')
+		} else {
+			return 0, false
+		}
+	}
+
+	if neg {
+		return -v, true
+	} else {
+		return v, true
+	}
+}

--- a/fastbytes_test.go
+++ b/fastbytes_test.go
@@ -1,0 +1,95 @@
+package jsonparser
+
+import (
+	"strconv"
+	"testing"
+	"unsafe"
+)
+
+type ParseIntTest struct {
+	in    string
+	out   int64
+	isErr bool
+}
+
+var parseIntTests = []ParseIntTest{
+	{
+		in:  "0",
+		out: 0,
+	},
+	{
+		in:  "1",
+		out: 1,
+	},
+	{
+		in:  "-1",
+		out: -1,
+	},
+	{
+		in:  "12345",
+		out: 12345,
+	},
+	{
+		in:  "-12345",
+		out: -12345,
+	},
+	{
+		in:  "9223372036854775807",
+		out: 9223372036854775807,
+	},
+	{
+		in:  "-9223372036854775808",
+		out: -9223372036854775808,
+	},
+	{
+		in:  "18446744073709551616", // = 2^64; integer overflow is not detected
+		out: 0,
+	},
+
+	{
+		in:    "",
+		isErr: true,
+	},
+	{
+		in:    "abc",
+		isErr: true,
+	},
+	{
+		in:    "12345x",
+		isErr: true,
+	},
+	{
+		in:    "123e5",
+		isErr: true,
+	},
+	{
+		in:    "9223372036854775807x",
+		isErr: true,
+	},
+}
+
+func TestBytesParseInt(t *testing.T) {
+	for _, test := range parseIntTests {
+		out, ok := BytesParseInt([]byte(test.in))
+		if ok != !test.isErr {
+			t.Errorf("Test '%s' error return did not match expectation (obtained %t, expected %t)", test.in, !ok, test.isErr)
+		} else if ok && out != test.out {
+			t.Errorf("Test '%s' did not return the expected value (obtained %d, expected %d)", test.in, out, test.out)
+		}
+	}
+}
+
+func BenchmarkParseInt(b *testing.B) {
+	bytes := []byte("123")
+	for i := 0; i < b.N; i++ {
+		BytesParseInt(bytes)
+	}
+}
+
+// Alternative implementation using unsafe and delegating to strconv.ParseInt
+func BenchmarkParseIntUnsafeSlower(b *testing.B) {
+	bytes := []byte("123")
+	for i := 0; i < b.N; i++ {
+		strconv.ParseInt(*(*string)(unsafe.Pointer(&bytes)), 10, 64)
+	}
+}

--- a/fastbytessafe.go
+++ b/fastbytessafe.go
@@ -1,0 +1,17 @@
+// +build appengine appenginevm
+
+package jsonparser
+
+import (
+	"strconv"
+)
+
+// See fastbytes_unsafe.go for explanation on why *[]byte is used (signatures must be consistent with those in that file)
+
+func BytesEqualStr(abytes *[]byte, bstr string) bool {
+	return string(*abytes) == bstr
+}
+
+func BytesParseFloat(bytes *[]byte, prec int) (float64, error) {
+	return strconv.ParseFloat(string(*bytes), prec)
+}

--- a/fastbytesunsafe.go
+++ b/fastbytesunsafe.go
@@ -1,0 +1,24 @@
+// +build !appengine,!appenginevm
+
+package jsonparser
+
+import (
+	"strconv"
+	"unsafe"
+)
+
+//
+// The reason for using *[]byte rather than []byte in parameters is an optimization. As of Go 1.6,
+// the compiler cannot perfectly inline the function when using a non-pointer slice. That is,
+// the non-pointer []byte parameter version is slower than if its function body is manually
+// inlined, whereas the pointer []byte version is equally fast to the manually inlined
+// version. Instruction count in assembly taken from "go tool compile" confirms this difference.
+//
+
+func BytesEqualStr(abytesptr *[]byte, bstr string) bool {
+	return *(*string)(unsafe.Pointer(abytesptr)) == bstr
+}
+
+func BytesParseFloat(bytesptr *[]byte, bitSize int) (float64, error) {
+	return strconv.ParseFloat(*(*string)(unsafe.Pointer(bytesptr)), bitSize)
+}

--- a/fastbytesunsafe_test.go
+++ b/fastbytesunsafe_test.go
@@ -1,0 +1,69 @@
+// +build !appengine,!appenginevm
+
+package jsonparser
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"unsafe"
+)
+
+var (
+	// short string/[]byte sequences, as the difference between these
+	// three methods is a constant overhead
+	benchmarkString = "0123456789x"
+	benchmarkBytes  = []byte("0123456789y")
+)
+
+func bytesEqualStrSafe(abytes []byte, bstr string) bool {
+	return bstr == string(abytes)
+}
+
+func bytesEqualStrUnsafeSlower(abytes *[]byte, bstr string) bool {
+	aslicehdr := (*reflect.SliceHeader)(unsafe.Pointer(abytes))
+	astrhdr := reflect.StringHeader{Data: aslicehdr.Data, Len: aslicehdr.Len}
+	return *(*string)(unsafe.Pointer(&astrhdr)) == bstr
+}
+
+func TestEqual(t *testing.T) {
+	if !BytesEqualStr(&[]byte{}, "") {
+		t.Errorf(`BytesEqualStr("", ""): expected true, obtained false`)
+		return
+	}
+
+	longstr := strings.Repeat("a", 1000)
+	for i := 0; i < len(longstr); i++ {
+		s1, s2 := longstr[:i]+"1", longstr[:i]+"2"
+		b1 := []byte(s1)
+
+		if !BytesEqualStr(&b1, s1) {
+			t.Errorf(`BytesEqualStr("a"*%d + "1", "a"*%d + "1"): expected true, obtained false`, i, i)
+			break
+		}
+		if BytesEqualStr(&b1, s2) {
+			t.Errorf(`BytesEqualStr("a"*%d + "1", "a"*%d + "2"): expected false, obtained true`, i, i)
+			break
+		}
+	}
+}
+
+func BenchmarkBytesEqualStr(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		BytesEqualStr(&benchmarkBytes, benchmarkString)
+	}
+}
+
+// Alternative implementation without using unsafe
+func BenchmarkBytesEqualStrSafe(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		bytesEqualStrSafe(benchmarkBytes, benchmarkString)
+	}
+}
+
+// Alternative implementation using unsafe, but that is slower than the current implementation
+func BenchmarkBytesEqualStrUnsafeSlower(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		bytesEqualStrUnsafeSlower(&benchmarkBytes, benchmarkString)
+	}
+}

--- a/parser.go
+++ b/parser.go
@@ -4,9 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"reflect"
 	"strconv"
-	"unsafe"
 )
 
 // Errors
@@ -127,10 +125,10 @@ func searchKeys(data []byte, keys ...string) int {
 
 			// if string is a Key, and key level match
 			if data[i] == ':' {
-				key := unsafeBytesToString(data[keyBegin:keyEnd])
+				candidateKey := data[keyBegin:keyEnd]
 
 				if keyLevel == level-1 && // If key nesting level match current object nested level
-					keys[level-1] == key {
+					BytesEqualStr(&candidateKey, keys[level-1]) {
 					keyLevel++
 					// If we found all keys in path
 					if keyLevel == lk {
@@ -343,17 +341,6 @@ func ArrayEach(data []byte, cb func(value []byte, dataType ValueType, offset int
 	return nil
 }
 
-// GetUnsafeString returns the value retrieved by `Get`, use creates string without memory allocation by mapping string to slice memory. It does not handle escape symbols.
-func GetUnsafeString(data []byte, keys ...string) (val string, err error) {
-	v, _, _, e := Get(data, keys...)
-
-	if e != nil {
-		return "", e
-	}
-
-	return unsafeBytesToString(v), nil
-}
-
 // GetString returns the value retrieved by `Get`, cast to a string if possible, trying to properly handle escape and utf8 symbols
 // If key data type do not match, it will return an error.
 func GetString(data []byte, keys ...string) (val string, err error) {
@@ -372,7 +359,7 @@ func GetString(data []byte, keys ...string) (val string, err error) {
 		return string(v), nil
 	}
 
-	s, err := strconv.Unquote(`"` + unsafeBytesToString(v) + `"`)
+	s, err := strconv.Unquote(`"` + string(v) + `"`)
 
 	return s, err
 }
@@ -391,7 +378,7 @@ func GetFloat(data []byte, keys ...string) (val float64, err error) {
 		return 0, fmt.Errorf("Value is not a number: %s", string(v))
 	}
 
-	val, err = strconv.ParseFloat(unsafeBytesToString(v), 64)
+	val, err = BytesParseFloat(&v, 64)
 	return
 }
 
@@ -408,8 +395,11 @@ func GetInt(data []byte, keys ...string) (val int64, err error) {
 		return 0, fmt.Errorf("Value is not a number: %s", string(v))
 	}
 
-	val, err = strconv.ParseInt(unsafeBytesToString(v), 10, 64)
-	return
+	if val, ok := BytesParseInt(v); !ok {
+		return 0, MalformedValueError
+	} else {
+		return val, nil
+	}
 }
 
 // GetBoolean returns the value retrieved by `Get`, cast to a bool if possible.
@@ -433,12 +423,4 @@ func GetBoolean(data []byte, keys ...string) (val bool, err error) {
 	}
 
 	return
-}
-
-// A hack until issue golang/go#2632 is fixed.
-// See: https://github.com/golang/go/issues/2632
-func unsafeBytesToString(data []byte) string {
-	h := (*reflect.SliceHeader)(unsafe.Pointer(&data))
-	sh := reflect.StringHeader{Data: h.Data, Len: h.Len}
-	return *(*string)(unsafe.Pointer(&sh))
 }


### PR DESCRIPTION
Pardon the unhelpful PR title; wasn't sure what to call this...

Removed the `unsafeBytesToString` function, instead encapsulating `unsafe` functionality in a separate set of files (`fastbytes*`), thus preventing misuse by client code. Included are fast implementations of `BytesEqualStr`, which takes one string and one []byte argument, and `BytesParseFloat` and `BytesParseInt`, which each take a `[]byte` argument. None of these functions let unsafe strings escape, thus improving overall safety.

The main benefit of this refactoring is the ability to have non-unsafe fallback versions of these functions for platforms without the `unsafe` package (such as Google App Engine). Such implementations are included in `fastbytessafe.go`.

A somewhat faster implementation of BytesEqualStr is included than was previously used in the codebase. Sadly, string equality checks are a small portion of overall `Get*()` cost now, so there is little net performance impact. A significantly faster implementation of BytesParseInt is also included, but has little net impact for the same reason.

No noticeable net change in the benchmark, however the code is now cleaner, safer, and more portable.

Note that this patch exports `Bytes{EqualStr,ParseInt,ParseFloat}`, as they may be of use to client code. This is far safer than the old method of exporting `GetUnsafeString`, as these new functions are safe.

**Benchmark before change**:
```
BenchmarkJsonParserLarge-8 	  100000	     62860 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserMedium-8	  500000	     10639 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserSmall-8 	10000000	       985 ns/op	       0 B/op	       0 allocs/op
```

**Benchmark after change**:
```
BenchmarkJsonParserLarge-8 	  100000	     62428 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserMedium-8	 1000000	     10779 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserSmall-8 	10000000	       996 ns/op	       0 B/op	       0 allocs/op
```