### PR TITLE
Improve performance of PR #21

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -23,18 +23,19 @@ func nextValue(data []byte) int {
 // Tries to find the end of string
 // Support if string contains escaped quote symbols.
 func stringEnd(data []byte) int {
-	escaped := false
 	for i, c := range data {
-		switch c {
-		case '\\':
-			escaped = !escaped
-		case '"':
-			if !escaped {
-				return i + 1
+		if c == '"' {
+			j := i - 1
+			for {
+				if j < 0 || data[j] != '\\' {
+					return i + 1 // even number of backslashes
+				}
+				j--
+				if j < 0 || data[j] != '\\' {
+					break // odd number of backslashes
+				}
+				j--
 			}
-			escaped = false
-		default:
-			escaped = false
 		}
 	}
 


### PR DESCRIPTION
Improved `stringEnd` performance by handling the escaped/unescaped state on every iteration, but instead backtracking from each double quote found and counting the number of preceding backslashes. This sounds more expensive, but it optimizes for the overwhelmingly common case that there is only one double quote (the end quote).

**Benchmark before change**:
<TODO>

**Benchmark after change**:
<TODO>
