### PR TITLE
Simpler (faster?) true/false/null literal checking

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -123,11 +123,11 @@ func searchKeys(data []byte, keys ...string) int {
 				data[i] == ':' && // if string is a Key, and key level match
 				keyLevel == level-1 && // If key nesting level match current object nested level
 				keys[level-1] == unsafeBytesToString(data[keyBegin:keyEnd]) {
-					keyLevel++
-					// If we found all keys in path
-					if keyLevel == lk {
-						return i + 1
-					}
+				keyLevel++
+				// If we found all keys in path
+				if keyLevel == lk {
+					return i + 1
+				}
 			}
 		case '{':
 			level++
@@ -155,6 +155,13 @@ const (
 	Boolean
 	Null
 	Unknown
+)
+
+// JSON literal keywords as byte slices for comparison in Get()
+var (
+	trueLiteral  = []byte("true")
+	falseLiteral = []byte("false")
+	nullLiteral  = []byte("null")
 )
 
 /*
@@ -222,17 +229,17 @@ func Get(data []byte, keys ...string) (value []byte, dataType int, offset int, e
 			return nil, dataType, offset, errors.New("Value looks like Number/Boolean/None, but can't find its end: ',' or '}' symbol")
 		}
 
-		value := unsafeBytesToString(data[offset : endOffset+end])
+		value := data[offset : endOffset+end]
 
 		switch data[offset] {
 		case 't', 'f': // true or false
-			if (len(value) == 4 && value == "true") || (len(value) == 5 && value == "false") {
+			if bytes.Equal(value, trueLiteral) || bytes.Equal(value, falseLiteral) {
 				dataType = Boolean
 			} else {
 				return nil, Unknown, offset, errors.New("Unknown value type")
 			}
-		case 'u', 'n': // undefined or null
-			if len(value) == 4 && value == "null" {
+		case 'n': // null
+			if bytes.Equal(value, nullLiteral) {
 				dataType = Null
 			} else {
 				return nil, Unknown, offset, errors.New("Unknown value type")

--- a/parser_test.go
+++ b/parser_test.go
@@ -347,7 +347,7 @@ var getBoolTests = []Test{
 		path:  []string{"a"},
 		isErr: true,
 	},
- 	Test{
+	Test{
 		desc:    `read boolean true with whitespace and another key`,
 		json:    "{\r\t\n \"a\"\r\t\n :\r\t\n true\r\t\n ,\r\t\n \"b\": 1}",
 		path:    []string{"a"},


### PR DESCRIPTION
This patch simplifies, and possibly speeds up, parsing of the literals `true`, `false`, and `null`. The current benchmarks do not test the parsing of booleans or null, so it's hard to say for sure whether the speed is improved.

**Benchmark after:**
BenchmarkJsonParserLarge-8 	  100000	     56923 ns/op
BenchmarkJsonParserMedium-8	  500000	     11938 ns/op
BenchmarkJsonParserSmall-8 	10000000	       915 ns/op

**Benchmark before:**
BenchmarkJsonParserLarge-8 	  200000	     56920 ns/op
BenchmarkJsonParserMedium-8	 1000000	     11469 ns/op
BenchmarkJsonParserSmall-8 	10000000	       965 ns/op
