### PR TITLE
Struct unmarshmaling and more

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SOURCE = parser.go
 CONTAINER = jsonparser
 SOURCE_PATH = /go/src/github.com/buger/jsonparser
-BENCHMARK = JsonParser
+BENCHMARK = JsonParserSmall
 BENCHTIME = 5s
 TEST = .
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SOURCE = parser.go
 CONTAINER = jsonparser
 SOURCE_PATH = /go/src/github.com/buger/jsonparser
-BENCHMARK = JsonParserSmall
+BENCHMARK = JsonParser
 BENCHTIME = 5s
 TEST = .
 

--- a/Makefile
+++ b/Makefile
@@ -4,30 +4,31 @@ SOURCE_PATH = /go/src/github.com/buger/jsonparser
 BENCHMARK = JsonParser
 BENCHTIME = 5s
 TEST = .
+DRUN = docker run -v `pwd`:$(SOURCE_PATH) -i -t $(CONTAINER)
 
 build:
 	docker build -t $(CONTAINER) .
 
 race:
-	docker run -v `pwd`:$(SOURCE_PATH) -i -t $(CONTAINER) --env GORACE="halt_on_error=1" go test ./. $(ARGS) -v -race -timeout 15s
+	$(DRUN) --env GORACE="halt_on_error=1" go test ./. $(ARGS) -v -race -timeout 15s
 
 bench:
-	docker run -v `pwd`:$(SOURCE_PATH) -i -t $(CONTAINER) go test $(LDFLAGS) -test.benchmem -bench $(BENCHMARK) ./benchmark/ $(ARGS) -benchtime $(BENCHTIME) -v
+	$(DRUN) go test $(LDFLAGS) -test.benchmem -bench $(BENCHMARK) ./benchmark/ $(ARGS) -benchtime $(BENCHTIME) -v
 
 profile:
-	docker run -v `pwd`:$(SOURCE_PATH) -i -t $(CONTAINER) go test $(LDFLAGS) -test.benchmem -bench $(BENCHMARK) ./benchmark/ $(ARGS) -memprofile mem.mprof -v
-	docker run -v `pwd`:$(SOURCE_PATH) -i -t $(CONTAINER) go test $(LDFLAGS) -test.benchmem -bench $(BENCHMARK) ./benchmark/ $(ARGS) -cpuprofile cpu.out -v
-	docker run -v `pwd`:$(SOURCE_PATH) -i -t $(CONTAINER) go test $(LDFLAGS) -test.benchmem -bench $(BENCHMARK) ./benchmark/ $(ARGS) -c
+	$(DRUN) go test $(LDFLAGS) -test.benchmem -bench $(BENCHMARK) ./benchmark/ $(ARGS) -memprofile mem.mprof -v
+	$(DRUN) go test $(LDFLAGS) -test.benchmem -bench $(BENCHMARK) ./benchmark/ $(ARGS) -cpuprofile cpu.out -v
+	$(DRUN) go test $(LDFLAGS) -test.benchmem -bench $(BENCHMARK) ./benchmark/ $(ARGS) -c
 
 test:
-	docker run -v `pwd`:$(SOURCE_PATH) -i -t $(CONTAINER) go test $(LDFLAGS) ./ -run $(TEST) -timeout 10s $(ARGS) -v
+	$(DRUN) go test $(LDFLAGS) ./ -run $(TEST) -timeout 10s $(ARGS) -v
 
 fmt:
-	docker run -v `pwd`:$(SOURCE_PATH) -i -t $(CONTAINER) go fmt ./...
+	$(DRUN) go fmt ./...
 
 vet:
-	docker run -v `pwd`:$(SOURCE_PATH) -i -t $(CONTAINER) go vet ./.
+	$(DRUN) go vet ./.
 
 
 bash:
-	docker run -v `pwd`:$(SOURCE_PATH) -i -t $(CONTAINER) /bin/bash
+	$(DRUN) /bin/bash

--- a/benchmark/benchmark_large_payload_test.go
+++ b/benchmark/benchmark_large_payload_test.go
@@ -35,7 +35,7 @@ func BenchmarkJsonParserLarge(b *testing.B) {
 	}
 }
 
-func BenchmarkJsonParserLargeOptimized(b *testing.B) {
+func BenchmarkJsonParserLargeOffsets(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		r := largeFixture
 		offsets := jsonparser.KeyOffsets(r,

--- a/benchmark/benchmark_large_payload_test.go
+++ b/benchmark/benchmark_large_payload_test.go
@@ -35,6 +35,28 @@ func BenchmarkJsonParserLarge(b *testing.B) {
 	}
 }
 
+func BenchmarkJsonParserLargeOptimized(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		r := largeFixture
+		offsets := jsonparser.KeyOffsets(r,
+			[]string{"users"},
+			[]string{"topics", "topics"},
+		)
+
+		jsonparser.ArrayEach(r[offsets[0]:], func(value []byte, dataType int, offset int, err error) {
+			jsonparser.Get(value, "username")
+			nothing()
+		})
+
+		jsonparser.ArrayEach(r[offsets[1]:], func(value []byte, dataType int, offset int, err error) {
+			aOff := jsonparser.KeyOffsets(value, []string{"id"}, []string{"slug"})
+			jsonparser.GetInt(value[aOff[0]:])
+			jsonparser.Get(value[aOff[1]:])
+			nothing()
+		})
+	}
+}
+
 /*
    encoding/json
 */

--- a/benchmark/benchmark_medium_payload_test.go
+++ b/benchmark/benchmark_medium_payload_test.go
@@ -34,7 +34,7 @@ func BenchmarkJsonParserMedium(b *testing.B) {
 	}
 }
 
-func BenchmarkJsonParserMediumOptimized(b *testing.B) {
+func BenchmarkJsonParserMediumOffsets(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		r := mediumFixture
 		offsets := jsonparser.KeyOffsets(r,
@@ -54,6 +54,20 @@ func BenchmarkJsonParserMediumOptimized(b *testing.B) {
 		})
 	}
 }
+
+// func BenchmarkJsonParserMediumStruct(b *testing.B) {
+// 	for i := 0; i < b.N; i++ {
+// 		var data MediumPayload
+// 		jsonparser.Unmarshal(mediumFixture, &data)
+
+// 		nothing(data.Person.Name.FullName, data.Person.Github.Followers, data.Company)
+
+// 		for _, el := range data.Person.Gravatar.Avatars {
+// 			nothing(el.Url)
+// 		}
+// 	}
+// }
+
 
 /*
    encoding/json

--- a/benchmark/benchmark_medium_payload_test.go
+++ b/benchmark/benchmark_medium_payload_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/pquerna/ffjson/ffjson"
 	"github.com/ugorji/go/codec"
 	"testing"
-	// "fmt"
+	_ "fmt"
 )
 
 /*
@@ -31,6 +31,27 @@ func BenchmarkJsonParserMedium(b *testing.B) {
 			jsonparser.Get(value, "url")
 			nothing()
 		}, "person", "gravatar", "avatars")
+	}
+}
+
+func BenchmarkJsonParserMediumOptimized(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		r := mediumFixture
+		offsets := jsonparser.KeyOffsets(r,
+			[]string{"person", "name", "fullName"},
+			[]string{"person", "github", "followers"},
+			[]string{"company"},
+			[]string{"person", "gravatar", "avatars"},
+		)
+
+		jsonparser.Get(r[offsets[0]:])
+		jsonparser.GetInt(r[offsets[1]:])
+		jsonparser.Get(r[offsets[2]:])
+
+		jsonparser.ArrayEach(r[offsets[3]:], func(value []byte, dataType int, offset int, err error) {
+			jsonparser.GetUnsafeString(value, "url")
+			nothing()
+		})
 	}
 }
 

--- a/benchmark/benchmark_small_payload_test.go
+++ b/benchmark/benchmark_small_payload_test.go
@@ -35,7 +35,7 @@ func BenchmarkJsonParserSmall(b *testing.B) {
 	}
 }
 
-func BenchmarkJsonParserSmallOptimized(b *testing.B) {
+func BenchmarkJsonParserSmallOffsets(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		r := smallFixture
 		offsets := jsonparser.KeyOffsets(r,
@@ -51,6 +51,14 @@ func BenchmarkJsonParserSmallOptimized(b *testing.B) {
 		jsonparser.GetInt(r[offsets[3]:])
 
 		nothing()
+	}
+}
+
+func BenchmarkJsonParserSmallStruct(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var data SmallPayload
+		jsonparser.Unmarshal(smallFixture, &data)
+		nothing(data.Uuid, data.Tz, data.Ua, data.St)
 	}
 }
 

--- a/benchmark/benchmark_small_payload_test.go
+++ b/benchmark/benchmark_small_payload_test.go
@@ -35,6 +35,26 @@ func BenchmarkJsonParserSmall(b *testing.B) {
 	}
 }
 
+func BenchmarkJsonParserSmallOptimized(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		r := smallFixture
+		offsets := jsonparser.KeyOffsets(r,
+			[]string{"uuid"},
+			[]string{"tz"},
+			[]string{"ua"},
+			[]string{"st"},
+		)
+
+		jsonparser.Get(r[offsets[0]:])
+		jsonparser.GetInt(r[offsets[1]:])
+		jsonparser.Get(r[offsets[2]:])
+		jsonparser.GetInt(r[offsets[3]:])
+
+		nothing()
+	}
+}
+
+
 /*
    encoding/json
 */

--- a/encode.go
+++ b/encode.go
@@ -1,0 +1,92 @@
+package jsonparser
+
+import (
+    "reflect"
+    "strings"
+    _ "fmt"
+)
+
+type structCache struct {
+    fields [][]string
+    fieldTypes []reflect.Kind
+}
+
+var cache map[string]*structCache
+
+func init() {
+    cache = make(map[string]*structCache)
+}
+
+func Unmarshal(data []byte, v interface{}) error {
+    val := reflect.ValueOf(v).Elem()
+
+    sName := val.Type().Name()
+    var sCache *structCache
+    var ok bool
+
+    // Cache struct info
+    if sCache, ok = cache[sName]; !ok {
+        count := val.NumField()
+        fields := make([][]string, count)
+        fieldTypes := make([]reflect.Kind, count)
+
+        for i := 0; i < val.NumField(); i++ {
+            valueField := val.Field(i)
+            typeField := val.Type().Field(i)
+            tag := typeField.Tag
+            jsonKey := tag.Get("json")
+
+            if jsonKey != "" {
+                fields[i] = []string{jsonKey}
+            } else {
+                fields[i] = []string{strings.ToLower(typeField.Name)}
+            }
+            fieldTypes[i] = valueField.Kind()
+        }
+
+        sCache = &structCache{fields, fieldTypes}
+        cache[sName] = sCache
+    }
+
+    fields := sCache.fields
+    fieldTypes := sCache.fieldTypes
+
+    offsets := KeyOffsets(data, fields...)
+
+    for i, of := range offsets {
+        f := val.Field(i)
+
+        if !f.IsValid() || !f.CanSet() {
+            continue
+        }
+
+        switch fieldTypes[i] {
+        case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+            v, err := GetInt(data[of:])
+
+            if err == nil {
+                f.SetInt(v)
+            }
+        case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+            v, err := GetInt(data[of:])
+
+            if err == nil {
+                f.SetUint(uint64(v))
+            }
+        case reflect.String:
+            v, err := GetString(data[of:])
+
+            if err == nil {
+                f.SetString(v)
+            }
+        case reflect.Bool:
+            v, err := GetBoolean(data[of:])
+
+            if err == nil {
+                f.SetBool(v)
+            }
+        }
+    }
+
+    return nil
+}

--- a/encode.go
+++ b/encode.go
@@ -17,9 +17,62 @@ func init() {
     cache = make(map[string]*structCache)
 }
 
-func Unmarshal(data []byte, v interface{}) error {
-    val := reflect.ValueOf(v).Elem()
+func unmarshalValue(data []byte, val reflect.Value) int {
+   if !val.IsValid() || !val.CanSet() {
+        return 0
+    }
 
+    v, dt, of, err := Get(data)
+
+    switch val.Kind() {
+    case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+        if dt == Number && err == nil {
+            val.SetInt(ParseInt(v))
+        }
+    case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+        if dt == Number && err == nil {
+            val.SetUint(uint64(ParseInt(v)))
+        }
+    case reflect.String:
+        if dt == String && err == nil {
+            val.SetString(unsafeBytesToString(v))
+        }
+    case reflect.Bool:
+        if dt == Boolean && err == nil {
+            val.SetBool(ParseBoolean(v))
+        }
+    case reflect.Ptr:
+        obj := reflect.New(val.Type().Elem())
+        unmarshalValue(v, obj.Elem())
+        val.Set(obj)
+    case reflect.Struct:
+        obj := reflect.New(val.Type())
+        unmarshalStruct(v, obj.Elem())
+        val.Set(obj.Elem())
+    case reflect.Slice:
+        sT := val.Type().Elem()
+        s := reflect.MakeSlice(val.Type(), 0, 0)
+        ArrayEach(v, func(value []byte, dataType int, offset int, err error){
+            el := reflect.New(sT)
+
+            switch sT.Kind() {
+            case reflect.Struct:
+                unmarshalStruct(value, el.Elem())
+            case reflect.Ptr:
+                unmarshalValue(value, el.Elem())
+            default:
+                unmarshalValue(value, el.Elem())
+            }
+
+            s = reflect.Append(s, el.Elem())
+        })
+        val.Set(s)
+    }
+
+    return of
+}
+
+func unmarshalStruct(data []byte, val reflect.Value) int {
     sName := val.Type().Name()
     var sCache *structCache
     var ok bool
@@ -28,10 +81,10 @@ func Unmarshal(data []byte, v interface{}) error {
     if sCache, ok = cache[sName]; !ok {
         count := val.NumField()
         fields := make([][]string, count)
-        fieldTypes := make([]reflect.Kind, count)
+        // fieldTypes := make([]reflect.Kind, count)
 
         for i := 0; i < val.NumField(); i++ {
-            valueField := val.Field(i)
+            // valueField := val.Field(i)
             typeField := val.Type().Field(i)
             tag := typeField.Tag
             jsonKey := tag.Get("json")
@@ -39,47 +92,32 @@ func Unmarshal(data []byte, v interface{}) error {
             if jsonKey != "" {
                 fields[i] = []string{jsonKey}
             } else {
-                fields[i] = []string{strings.ToLower(typeField.Name)}
+                fields[i] = []string{strings.ToLower(string(typeField.Name[:1])) + string(typeField.Name[1:])}
             }
-            fieldTypes[i] = valueField.Kind()
+            // fieldTypes[i] = valueField.Kind()
         }
 
-        sCache = &structCache{fields, fieldTypes}
+        sCache = &structCache{fields: fields}
         cache[sName] = sCache
     }
 
     fields := sCache.fields
-    fieldTypes := sCache.fieldTypes
+    // fieldTypes := sCache.fieldTypes
 
-    KeyEach(data, func(i int, d []byte) int {
+    offset := KeyEach(data, func(i int, d []byte) int {
         f := val.Field(i)
-        if !f.IsValid() || !f.CanSet() {
-            return 0
-        }
 
-        v, dt, of, err := Get(d)
-
-        switch fieldTypes[i] {
-        case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-            if dt == Number && err == nil {
-                f.SetInt(ParseInt(v))
-            }
-        case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-            if dt == Number && err == nil {
-                f.SetUint(uint64(ParseInt(v)))
-            }
-        case reflect.String:
-            if dt == String && err == nil {
-                f.SetString(unsafeBytesToString(v))
-            }
-        case reflect.Bool:
-            if dt == Boolean && err == nil {
-                f.SetBool(ParseBoolean(v))
-            }
-        }
-
-        return of
+        return unmarshalValue(d, f)
     }, fields...)
+    // panic(string(data))
+
+    return offset
+}
+
+func Unmarshal(data []byte, v interface{}) error {
+    val := reflect.ValueOf(v).Elem()
+
+    unmarshalStruct(data, val)
 
     return nil
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -513,3 +513,38 @@ func TestGetSlice(t *testing.T) {
 		},
 	)
 }
+
+type testStruct struct {
+	Name string
+	Order string
+	Sum int
+	Len int8
+	VERYLONGFIELD bool `json:"isPaid"`
+}
+
+var testJson = []byte(`{"name": "Name", "order":"Order", "sum": 100, "len": 12, "isPaid": true}`)
+
+func TestUnmarshal(t *testing.T) {
+	var s testStruct
+	Unmarshal(testJson, &s)
+
+	if s.Name != "Name" {
+		t.Errorf("Should fill Name field")
+	}
+
+	if s.Order != "Order" {
+		t.Errorf("Should fill Order field")
+	}
+
+	if s.Sum != 100 {
+		t.Errorf("Should fill Sum field")
+	}
+
+	if s.Len != 12 {
+		t.Errorf("Should process int8")
+	}
+
+	if !s.VERYLONGFIELD {
+		t.Errorf("Should process boolean and custom name")
+	}
+}

--- a/parser_test.go
+++ b/parser_test.go
@@ -514,15 +514,27 @@ func TestGetSlice(t *testing.T) {
 	)
 }
 
+type nestedStruct struct {
+	A string
+	B int
+
+	N *nestedStruct `json:"nested3"`
+}
+
 type testStruct struct {
 	Name string
 	Order string
 	Sum int
 	Len int8
 	VERYLONGFIELD bool `json:"isPaid"`
+	NestedPtr *nestedStruct `json:"nested"`
+	Nested nestedStruct `json:"nested2"`
+	Arr []nestedStruct
+	ArrInt []int
+	IntPtr *int
 }
 
-var testJson = []byte(`{"name": "Name", "order":"Order", "sum": 100, "len": 12, "isPaid": true}`)
+var testJson = []byte(`{"name": "Name", "order":"Order", "sum": 100, "len": 12, "isPaid": true, "nested": {"a":"test", "b":2, "nested3":{"a":"test3","b":4}, "c": "unknown"}, "nested2": {"a":"test2", "b":3}, "arr": [{"a":"zxc", "b": 1}, {"a":"123", "b":2}], "arrInt": [1,2,3,4], "intPtr": 10}`)
 
 func TestUnmarshal(t *testing.T) {
 	var s testStruct
@@ -547,4 +559,144 @@ func TestUnmarshal(t *testing.T) {
 	if !s.VERYLONGFIELD {
 		t.Errorf("Should process boolean and custom name")
 	}
+
+	if s.NestedPtr == nil {
+		t.Errorf("Should initialize nested pointer to struct")
+	} else {
+		if s.NestedPtr.A != "test" || s.NestedPtr.B != 2 {
+			t.Errorf("Should fill nested pointer to struct %v", s.NestedPtr)
+		}
+
+		if s.NestedPtr.N == nil {
+			t.Errorf("Should initialize deeply nested pointer to struct")
+		} else {
+			if s.NestedPtr.N.A != "test3" || s.NestedPtr.N.B != 4 {
+				t.Errorf("Should fill nested pointer to struct %v", s.NestedPtr.N)
+			}
+		}
+	}
+
+	if s.Nested.A != "test2" || s.Nested.B != 3 {
+		t.Errorf("Should fill nested struct %v", s.Nested)
+	}
+
+	if len(s.Arr) != 2 {
+		t.Errorf("Should fill array")
+	} else {
+		if s.Arr[0].A != "zxc" && s.Arr[0].B != 1 {
+			t.Errorf("Should fill first array item")
+		}
+		if s.Arr[1].A != "123" && s.Arr[1].B != 2 {
+			t.Errorf("Should fill first array item")
+		}
+	}
+
+	if len(s.ArrInt) != 4 {
+		t.Errorf("Should fill int array")
+	} else {
+		if !reflect.DeepEqual(s.ArrInt, []int{1,2,3,4}) {
+			t.Errorf("Should fill int array with proper values %v", s.ArrInt)
+		}
+	}
+
+	if *s.IntPtr != 10 {
+		t.Errorf("Should update simple type pointer")
+	}
 }
+
+// var fixture []byte = []byte(`{
+//   "person": {
+//     "id": "d50887ca-a6ce-4e59-b89f-14f0b5d03b03",
+//     "name": {
+//       "fullName": "Leonid Bugaev",
+//       "givenName": "Leonid",
+//       "familyName": "Bugaev"
+//     },
+//     "email": "leonsbox@gmail.com",
+//     "gender": "male",
+//     "location": "Saint Petersburg, Saint Petersburg, RU",
+//     "geo": {
+//       "city": "Saint Petersburg",
+//       "state": "Saint Petersburg",
+//       "country": "Russia",
+//       "lat": 59.9342802,
+//       "lng": 30.3350986
+//     },
+//     "bio": "Senior engineer at Granify.com",
+//     "site": "http://flickfaver.com",
+//     "avatar": "https://d1ts43dypk8bqh.cloudfront.net/v1/avatars/d50887ca-a6ce-4e59-b89f-14f0b5d03b03",
+//     "employment": {
+//       "name": "www.latera.ru",
+//       "title": "Software Engineer",
+//       "domain": "gmail.com"
+//     },
+//     "facebook": {
+//       "handle": "leonid.bugaev"
+//     },
+//     "github": {
+//       "handle": "buger",
+//       "id": 14009,
+//       "avatar": "https://avatars.githubusercontent.com/u/14009?v=3",
+//       "company": "Granify",
+//       "blog": "http://leonsbox.com",
+//       "followers": 95,
+//       "following": 10
+//     },
+//     "twitter": {
+//       "handle": "flickfaver",
+//       "id": 77004410,
+//       "bio": null,
+//       "followers": 2,
+//       "following": 1,
+//       "statuses": 5,
+//       "favorites": 0,
+//       "location": "",
+//       "site": "http://flickfaver.com",
+//       "avatar": null
+//     },
+//     "linkedin": {
+//       "handle": "in/leonidbugaev"
+//     },
+//     "googleplus": {
+//       "handle": null
+//     },
+//     "angellist": {
+//       "handle": "leonid-bugaev",
+//       "id": 61541,
+//       "bio": "Senior engineer at Granify.com",
+//       "blog": "http://buger.github.com",
+//       "site": "http://buger.github.com",
+//       "followers": 41,
+//       "avatar": "https://d1qb2nb5cznatu.cloudfront.net/users/61541-medium_jpg?1405474390"
+//     },
+//     "klout": {
+//       "handle": null,
+//       "score": null
+//     },
+//     "foursquare": {
+//       "handle": null
+//     },
+//     "aboutme": {
+//       "handle": "leonid.bugaev",
+//       "bio": null,
+//       "avatar": null
+//     },
+//     "gravatar": {
+//       "handle": "buger",
+//       "urls": [
+
+//       ],
+//       "avatar": "http://1.gravatar.com/avatar/f7c8edd577d13b8930d5522f28123510",
+//       "avatars": [
+//         {
+//           "url": "http://1.gravatar.com/avatar/f7c8edd577d13b8930d5522f28123510",
+//           "type": "thumbnail"
+//         }
+//       ]
+//     },
+//     "fuzzy": false
+//   },
+//   "company": null
+// }`)
+
+


### PR DESCRIPTION
This is ongoing PR but i wanted to show what i'm working on right now. 

There is 2 major changes here:
- Support for querying multiple keys at once
- Struct unmarshmaling, same way as `encoding/json` works (use feature above)

I added new API function `KeyOffset` which returns offsets in base data structure for all keys at once, so it can do less reads.

Here is example taken from benchmark:

```
r := smallFixture
offsets := jsonparser.KeyOffsets(r,
    []string{"uuid"},
    []string{"tz"},
    []string{"ua"},
    []string{"st"},
)

jsonparser.Get(r[offsets[0]:])
jsonparser.GetInt(r[offsets[1]:])
jsonparser.Get(r[offsets[2]:])
jsonparser.GetInt(r[offsets[3]:])
```

As you can see from UX perspective it looks way worse, but it can give significant speedup, see benchmarks below. As future improvement i wanted implement iterator like access, similar to `ArrayEach` which reduce number of reads even more.

Based on feature above, i implemented basic version of Unmarshaler, you can check the code and bechmarks (looks not bad, considering that it does not use code generation). As unique feature i plan add support for nested keys, so you can specify them like:

```
struct Person {
    githubFollowers int `json:"person.github.followers_count"`
    ...
}
```

Here is initial benchmarks:

```
BenchmarkJsonParserLarge              100000         75014 ns/op          32 B/op          2 allocs/op
BenchmarkJsonParserLargeOffsets       100000         81327 ns/op         528 B/op         33 allocs/op
BenchmarkJsonParserMedium             500000         15577 ns/op          48 B/op          3 allocs/op
BenchmarkJsonParserMediumOffsets     1000000          7757 ns/op          80 B/op          4 allocs/op
BenchmarkJsonParserSmall             5000000          1289 ns/op           0 B/op          0 allocs/op
BenchmarkJsonParserSmallOffsets     10000000          1065 ns/op          32 B/op          1 allocs/op
BenchmarkJsonParserSmallStruct       2000000          3280 ns/op         384 B/op         11 allocs/op
```

`KeyOffsets` can be optimized much more in my view.
