### PR TITLE
Fix incorrect skipping of characters in searchKeys parser

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -4,9 +4,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"reflect"
+	"github.com/buger/jsonparser/strbytes"
 	"strconv"
-	"unsafe"
 )
 
 func tokenEnd(data []byte) int {
@@ -122,12 +121,12 @@ func searchKeys(data []byte, keys ...string) int {
 			if i < ln &&
 				data[i] == ':' && // if string is a Key, and key level match
 				keyLevel == level-1 && // If key nesting level match current object nested level
-				keys[level-1] == unsafeBytesToString(data[keyBegin:keyEnd]) {
-					keyLevel++
-					// If we found all keys in path
-					if keyLevel == lk {
-						return i + 1
-					}
+				strbytes.Equal(keys[level-1], data[keyBegin:keyEnd]) {
+				keyLevel++
+				// If we found all keys in path
+				if keyLevel == lk {
+					return i + 1
+				}
 			}
 		case '{':
 			level++
@@ -222,7 +221,7 @@ func Get(data []byte, keys ...string) (value []byte, dataType int, offset int, e
 			return nil, dataType, offset, errors.New("Value looks like Number/Boolean/None, but can't find its end: ',' or '}' symbol")
 		}
 
-		value := unsafeBytesToString(data[offset : endOffset+end])
+		value := string(data[offset : endOffset+end])
 
 		switch data[offset] {
 		case 't', 'f': // true or false
@@ -310,17 +309,6 @@ func ArrayEach(data []byte, cb func(value []byte, dataType int, offset int, err 
 	return nil
 }
 
-// GetUnsafeString returns the value retrieved by `Get`, use creates string without memory allocation by mapping string to slice memory. It does not handle escape symbols.
-func GetUnsafeString(data []byte, keys ...string) (val string, err error) {
-	v, _, _, e := Get(data, keys...)
-
-	if e != nil {
-		return "", e
-	}
-
-	return unsafeBytesToString(v), nil
-}
-
 // GetString returns the value retrieved by `Get`, cast to a string if possible, trying to properly handle escape and utf8 symbols
 // If key data type do not match, it will return an error.
 func GetString(data []byte, keys ...string) (val string, err error) {
@@ -339,7 +327,7 @@ func GetString(data []byte, keys ...string) (val string, err error) {
 		return string(v), nil
 	}
 
-	s, err := strconv.Unquote(`"` + unsafeBytesToString(v) + `"`)
+	s, err := strconv.Unquote(`"` + string(v) + `"`)
 
 	return s, err
 }
@@ -358,7 +346,7 @@ func GetFloat(data []byte, keys ...string) (val float64, err error) {
 		return 0, fmt.Errorf("Value is not a number: %s", string(v))
 	}
 
-	val, err = strconv.ParseFloat(unsafeBytesToString(v), 64)
+	val, err = strbytes.ParseFloat(v, 64)
 	return
 }
 
@@ -375,7 +363,7 @@ func GetInt(data []byte, keys ...string) (val int64, err error) {
 		return 0, fmt.Errorf("Value is not a number: %s", string(v))
 	}
 
-	val, err = strconv.ParseInt(unsafeBytesToString(v), 10, 64)
+	val, err = strbytes.ParseInt(v, 10, 64)
 	return
 }
 
@@ -400,12 +388,4 @@ func GetBoolean(data []byte, keys ...string) (val bool, err error) {
 	}
 
 	return
-}
-
-// A hack until issue golang/go#2632 is fixed.
-// See: https://github.com/golang/go/issues/2632
-func unsafeBytesToString(data []byte) string {
-	h := (*reflect.SliceHeader)(unsafe.Pointer(&data))
-	sh := reflect.StringHeader{Data: h.Data, Len: h.Len}
-	return *(*string)(unsafe.Pointer(&sh))
 }

--- a/parser.go
+++ b/parser.go
@@ -118,15 +118,23 @@ func searchKeys(data []byte, keys ...string) int {
 			}
 			i += valueOffset
 
-			if i < ln &&
-				data[i] == ':' && // if string is a Key, and key level match
-				keyLevel == level-1 && // If key nesting level match current object nested level
-				strbytes.Equal(keys[level-1], data[keyBegin:keyEnd]) {
-				keyLevel++
-				// If we found all keys in path
-				if keyLevel == lk {
-					return i + 1
+			if i >= ln {
+				break
+			}
+
+			if data[i] == ':' {
+				// If we see a colon, this is a key, so check the key against our next search key
+				if keyLevel == level-1 && strbytes.Equal(keys[level-1], data[keyBegin:keyEnd]) {
+					// If we found the key we're looking for at the right nesting level, advance to the next key
+					keyLevel++
+					// If we found all keys in path
+					if keyLevel == lk {
+						return i + 1
+					}
 				}
+			} else {
+				// Else, backtrack one character so data[i] can be processed by the next iteration (e.g., it might have been a '}')
+				i--
 			}
 		case '{':
 			level++

--- a/parser_test.go
+++ b/parser_test.go
@@ -144,6 +144,13 @@ var getTests = []Test{
 		isFound: true,
 		data:    `15°C`,
 	},
+	Test{
+		desc:    `no padding + nested`,
+		json:    `{"a":{"a":1},"b":2}`,
+		path:    []string{"b"},
+		isFound: true,
+		data:    `2`,
+	},
 
 	// Not found key tests
 	Test{

--- a/parser_test.go
+++ b/parser_test.go
@@ -347,7 +347,7 @@ var getBoolTests = []Test{
 		path:  []string{"a"},
 		isErr: true,
 	},
- 	Test{
+	Test{
 		desc:    `read boolean true with whitespace and another key`,
 		json:    "{\r\t\n \"a\"\r\t\n :\r\t\n true\r\t\n ,\r\t\n \"b\": 1}",
 		path:    []string{"a"},

--- a/strbytes/safe.go
+++ b/strbytes/safe.go
@@ -1,0 +1,19 @@
+// +build appengine appenginevm
+
+package strbytes
+
+import (
+	"strconv"
+)
+
+func Equal(astr string, bbytes []byte) bool {
+	return astr == string(bbytes)
+}
+
+func ParseFloat(bytes []byte, prec int) (float64, error) {
+	return strconv.ParseFloat(string(bytes), prec)
+}
+
+func ParseInt(bytes []byte, base int, bitSize int) (int64, error) {
+	return strconv.ParseInt(string(bytes), base, bitSize)
+}

--- a/strbytes/unsafe.go
+++ b/strbytes/unsafe.go
@@ -1,0 +1,38 @@
+// +build !appengine,!appenginevm
+
+package strbytes
+
+import (
+	"reflect"
+	"strconv"
+	"unsafe"
+)
+
+func equalSafe(astr string, bbytes []byte) bool {
+	return astr == string(bbytes)
+}
+
+func equalUnsafe(astr string, bbytes []byte) bool {
+	bslicehdr := (*reflect.SliceHeader)(unsafe.Pointer(&bbytes))
+	bstrhdr := reflect.StringHeader{Data: bslicehdr.Data, Len: bslicehdr.Len}
+	bstr := *(*string)(unsafe.Pointer(&bstrhdr))
+	return astr == bstr
+}
+func equalMoreUnsafe(astr string, bbytes []byte) bool {
+	bstr := *(*string)(unsafe.Pointer(&bbytes))
+	return astr == bstr
+}
+
+func Equal(astr string, bbytes []byte) bool {
+	return equalMoreUnsafe(astr, bbytes)
+}
+
+func ParseFloat(bytes []byte, bitSize int) (float64, error) {
+	str := *(*string)(unsafe.Pointer(&bytes))
+	return strconv.ParseFloat(str, bitSize)
+}
+
+func ParseInt(bytes []byte, base int, bitSize int) (int64, error) {
+	str := *(*string)(unsafe.Pointer(&bytes))
+	return strconv.ParseInt(str, base, bitSize)
+}

--- a/strbytes/unsafe_test.go
+++ b/strbytes/unsafe_test.go
@@ -1,0 +1,66 @@
+// +build !appengine,!appenginevm
+
+package strbytes
+
+import (
+	"strings"
+	"testing"
+)
+
+type eqFn func(string, []byte) bool
+
+func TestEqual(t *testing.T) {
+	eqs := map[string]eqFn{
+		"safeEqual":       equalSafe,
+		"unsafeEqual":     equalUnsafe,
+		"moreUnsafeEqual": equalMoreUnsafe,
+	}
+
+	longstr := strings.Repeat("a", 1000)
+
+	for eqName, eq := range eqs {
+		if !eq("", []byte("")) {
+			t.Errorf(`%s("", ""): expected true, obtained false`, eqName)
+			break
+		}
+
+		for i := 0; i < len(longstr); i++ {
+			s1, s2 := longstr[:i]+"1", longstr[:i]+"2"
+			b1 := []byte(s1)
+
+			if !eq(s1, b1) {
+				t.Errorf(`%s("a"*%d + "1", "a"*%d + "1"): expected true, obtained false`, eqName, i, i)
+				break
+			}
+			if eq(s2, b1) {
+				t.Errorf(`%s("a"*%d + "1", "a"*%d + "2"): expected false, obtained true`, eqName, i, i)
+				break
+			}
+		}
+	}
+}
+
+var (
+	// short string/[]byte sequences, as the difference between these
+	// three methods is a constant overhead
+	benchmarkString = "0123456789x"
+	benchmarkBytes  = []byte("0123456789y")
+)
+
+func BenchmarkSafe(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		equalSafe(benchmarkString, benchmarkBytes)
+	}
+}
+
+func BenchmarkUnsafe(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		equalUnsafe(benchmarkString, benchmarkBytes)
+	}
+}
+
+func BenchmarkMoreUnsafe(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		equalMoreUnsafe(benchmarkString, benchmarkBytes)
+	}
+}


### PR DESCRIPTION
NOTE: This PR depends on (i.e., includes) PR #25. Don't merge it until #25 is merged, or do the merge manually. Sorry for the trouble.

Previously, searchKeys would skip the character right after a string when parsing. This caused it to miss closing `}` characters to properly decrement the `keyLevel`, which caused all sorts of issues.

Now, searchKeys will backtrack one character if the character after the string is not a colon (if it is a colon, it does the usual key check, etc., and all is well).