### PR TITLE
Fixed searchKeys parser skips chars after array

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -121,8 +121,8 @@ func searchKeys(data []byte, keys ...string) int {
 			i += valueOffset
 
 			// if string is a Key, and key level match
-			if data[i] == ':'{
-			 	if keyLevel == level-1 && // If key nesting level match current object nested level
+			if data[i] == ':' {
+				if keyLevel == level-1 && // If key nesting level match current object nested level
 					keys[level-1] == string(data[keyBegin:keyEnd]) {
 					keyLevel++
 					// If we found all keys in path
@@ -140,7 +140,7 @@ func searchKeys(data []byte, keys ...string) int {
 		case '[':
 			// Do not search for keys inside arrays
 			arraySkip := blockEnd(data[i:], '[', ']')
-			i += arraySkip
+			i += arraySkip - 1
 		}
 
 		i++

--- a/parser_test.go
+++ b/parser_test.go
@@ -151,6 +151,13 @@ var getTests = []Test{
 		isFound: true,
 		data:    `2`,
 	},
+	Test{
+		desc:    `no padding + nested + array`,
+		json:    `{"a":{"b":[1,2]},"c":3}`,
+		path:    []string{"c"},
+		isFound: true,
+		data:    `3`,
+	},
 
 	// Not found key tests
 	Test{


### PR DESCRIPTION
Similar fix to #30, but this one is properly based on `master` like a sane PR :).