### PR TITLE
Using new ValueType instead of int for dataType

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -150,8 +150,10 @@ func searchKeys(data []byte, keys ...string) int {
 }
 
 // Data types available in valid JSON data.
+type ValueType int
+
 const (
-	NotExist = iota
+	NotExist = ValueType(iota)
 	String
 	Number
 	Object
@@ -179,7 +181,7 @@ Returns:
 Accept multiple keys to specify path to JSON value (in case of quering nested structures).
 If no keys provided it will try to extract closest JSON value (simple ones or object/array), useful for reading streams or arrays, see `ArrayEach` implementation.
 */
-func Get(data []byte, keys ...string) (value []byte, dataType int, offset int, err error) {
+func Get(data []byte, keys ...string) (value []byte, dataType ValueType, offset int, err error) {
 	if len(keys) > 0 {
 		if offset = searchKeys(data, keys...); offset == -1 {
 			return []byte{}, NotExist, -1, errors.New("Key path not found")
@@ -271,7 +273,7 @@ func Get(data []byte, keys ...string) (value []byte, dataType int, offset int, e
 }
 
 // ArrayEach is used when iterating arrays, accepts a callback function with the same return arguments as `Get`.
-func ArrayEach(data []byte, cb func(value []byte, dataType int, offset int, err error), keys ...string) (err error) {
+func ArrayEach(data []byte, cb func(value []byte, dataType ValueType, offset int, err error), keys ...string) (err error) {
 	if len(data) == 0 {
 		return errors.New("Object is empty")
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -11,7 +11,7 @@ import (
 var activeTest = ""
 
 func toArray(data []byte) (result [][]byte) {
-	ArrayEach(data, func(value []byte, dataType int, offset int, err error) {
+	ArrayEach(data, func(value []byte, dataType ValueType, offset int, err error) {
 		result = append(result, value)
 	})
 
@@ -19,7 +19,7 @@ func toArray(data []byte) (result [][]byte) {
 }
 
 func toStringArray(data []byte) (result []string) {
-	ArrayEach(data, func(value []byte, dataType int, offset int, err error) {
+	ArrayEach(data, func(value []byte, dataType ValueType, offset int, err error) {
 		result = append(result, string(value))
 	})
 
@@ -403,7 +403,7 @@ var getArrayTests = []Test{
 
 // checkFoundAndNoError checks the dataType and error return from Get*() against the test case expectations.
 // Returns true the test should proceed to checking the actual data returned from Get*(), or false if the test is finished.
-func checkFoundAndNoError(t *testing.T, testKind string, test Test, jtype int, value interface{}, err error) bool {
+func checkFoundAndNoError(t *testing.T, testKind string, test Test, jtype ValueType, value interface{}, err error) bool {
 	isFound := (jtype != NotExist)
 	isErr := (err != nil)
 
@@ -427,7 +427,7 @@ func checkFoundAndNoError(t *testing.T, testKind string, test Test, jtype int, v
 	}
 }
 
-func runTests(t *testing.T, tests []Test, runner func(Test) (interface{}, int, error), typeChecker func(Test, interface{}) (bool, interface{})) {
+func runTests(t *testing.T, tests []Test, runner func(Test) (interface{}, ValueType, error), typeChecker func(Test, interface{}) (bool, interface{})) {
 	for _, test := range tests {
 		if activeTest != "" && test.desc != activeTest {
 			continue
@@ -458,7 +458,7 @@ func runTests(t *testing.T, tests []Test, runner func(Test) (interface{}, int, e
 
 func TestGet(t *testing.T) {
 	runTests(t, getTests,
-		func(test Test) (value interface{}, dataType int, err error) {
+		func(test Test) (value interface{}, dataType ValueType, err error) {
 			value, dataType, _, err = Get([]byte(test.json), test.path...)
 			return
 		},
@@ -471,7 +471,7 @@ func TestGet(t *testing.T) {
 
 func TestGetString(t *testing.T) {
 	runTests(t, getStringTests,
-		func(test Test) (value interface{}, dataType int, err error) {
+		func(test Test) (value interface{}, dataType ValueType, err error) {
 			value, err = GetString([]byte(test.json), test.path...)
 			return value, String, err
 		},
@@ -484,7 +484,7 @@ func TestGetString(t *testing.T) {
 
 func TestGetInt(t *testing.T) {
 	runTests(t, getIntTests,
-		func(test Test) (value interface{}, dataType int, err error) {
+		func(test Test) (value interface{}, dataType ValueType, err error) {
 			value, err = GetInt([]byte(test.json), test.path...)
 			return value, Number, err
 		},
@@ -497,7 +497,7 @@ func TestGetInt(t *testing.T) {
 
 func TestGetFloat(t *testing.T) {
 	runTests(t, getFloatTests,
-		func(test Test) (value interface{}, dataType int, err error) {
+		func(test Test) (value interface{}, dataType ValueType, err error) {
 			value, err = GetFloat([]byte(test.json), test.path...)
 			return value, Number, err
 		},
@@ -510,7 +510,7 @@ func TestGetFloat(t *testing.T) {
 
 func TestGetBoolean(t *testing.T) {
 	runTests(t, getBoolTests,
-		func(test Test) (value interface{}, dataType int, err error) {
+		func(test Test) (value interface{}, dataType ValueType, err error) {
 			value, err = GetBoolean([]byte(test.json), test.path...)
 			return value, Boolean, err
 		},
@@ -523,7 +523,7 @@ func TestGetBoolean(t *testing.T) {
 
 func TestGetSlice(t *testing.T) {
 	runTests(t, getArrayTests,
-		func(test Test) (value interface{}, dataType int, err error) {
+		func(test Test) (value interface{}, dataType ValueType, err error) {
 			value, dataType, _, err = Get([]byte(test.json), test.path...)
 			return
 		},


### PR DESCRIPTION
Made a new type, `ValueType`, which is now used everywhere for `dataType` in place of `int`. This seems more Go idiomatic and also type-safer (no accidental confusion with the `offset` return, for instance). Requires minor changes to code that calls into this library.