### PR TITLE
Better error handling

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -9,6 +9,11 @@ import (
 	"unsafe"
 )
 
+var (
+	KeyPathNotFoundError = errors.New("Key path not found")
+	UnknownValueTypeError = errors.New("Unknown value type")
+)
+
 func tokenEnd(data []byte) int {
 	for i, c := range data {
 		switch c {
@@ -182,7 +187,7 @@ If no keys provided it will try to extract closest JSON value (simple ones or ob
 func Get(data []byte, keys ...string) (value []byte, dataType int, offset int, err error) {
 	if len(keys) > 0 {
 		if offset = searchKeys(data, keys...); offset == -1 {
-			return []byte{}, NotExist, -1, errors.New("Key path not found")
+			return []byte{}, NotExist, -1, KeyPathNotFoundError
 		}
 	}
 
@@ -239,18 +244,18 @@ func Get(data []byte, keys ...string) (value []byte, dataType int, offset int, e
 			if bytes.Equal(value, trueLiteral) || bytes.Equal(value, falseLiteral) {
 				dataType = Boolean
 			} else {
-				return nil, Unknown, offset, errors.New("Unknown value type")
+				return nil, Unknown, offset, UnknownValueTypeError
 			}
 		case 'u', 'n': // undefined or null
 			if bytes.Equal(value, nullLiteral) {
 				dataType = Null
 			} else {
-				return nil, Unknown, offset, errors.New("Unknown value type")
+				return nil, Unknown, offset, UnknownValueTypeError
 			}
 		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-':
 			dataType = Number
 		default:
-			return nil, Unknown, offset, errors.New("Unknown value type")
+			return nil, Unknown, offset, UnknownValueTypeError
 		}
 
 		endOffset += end
@@ -280,7 +285,7 @@ func ArrayEach(data []byte, cb func(value []byte, dataType int, offset int, err 
 
 	if len(keys) > 0 {
 		if offset = searchKeys(data, keys...); offset == -1 {
-			return errors.New("Key path not found")
+			return KeyPathNotFoundError
 		}
 
 		// Go to closest value

--- a/parser_test.go
+++ b/parser_test.go
@@ -418,6 +418,10 @@ func checkFoundAndNoError(t *testing.T, testKind string, test Test, jtype int, v
 		// Else, if the call didn't match the is-found expectation, fail
 		t.Errorf("%s test '%s' isFound mismatch: expected %t, obtained %t", testKind, test.desc, test.isFound, isFound)
 		return false
+	} else if !isFound && err != KeyPathNotFoundError {
+		// Else, if no value was found and the error is not correct, fail
+		t.Errorf("%s test '%s' error mismatch: expected %t, obtained %t", testKind, test.desc, KeyPathNotFoundError, err)
+		return false
 	} else if !isFound {
 		// Else, if no value was found, don't fail and don't check the value
 		return false


### PR DESCRIPTION
**Description**: 
This PR exports some errors as global variables to easier check for errors when calling Get* methods.

For now I exported just two errors, key path not found and unknown value type. If you think this type of error management is good I can change it also for other errors where it would make sense.

**Benchmark before change**:
`enchmarkJsonParserLarge-8 	  100000	     73036 ns/op	      32 B/op	       2 allocs/op`
`BenchmarkJsonParserMedium-8	  500000	     12253 ns/op	      32 B/op	       2 allocs/op`
`BenchmarkJsonParserSmall-8 	 5000000	      1217 ns/op	       0 B/op	       0 allocs/op`

**Benchmark after change**:
`BenchmarkJsonParserLarge-8 	  100000	     74244 ns/op	       0 B/op	       0 allocs/op`
`BenchmarkJsonParserMedium-8	  500000	     12597 ns/op	       0 B/op	       0 allocs/op`
`BenchmarkJsonParserSmall-8 	 5000000	      1145 ns/op	       0 B/op	       0 allocs/op`

