### PR TITLE
Handle escaped keys and values in JSON

### DIFF
--- a/bytes_safe.go
+++ b/bytes_safe.go
@@ -17,5 +17,5 @@ func parseFloat(b *[]byte) (float64, error) {
 }
 
 func bytesToString(b *[]byte) string {
-  return string(*b)
+	return string(*b)
 }

--- a/bytes_unsafe.go
+++ b/bytes_unsafe.go
@@ -27,5 +27,5 @@ func parseFloat(b *[]byte) (float64, error) {
 // A hack until issue golang/go#2632 is fixed.
 // See: https://github.com/golang/go/issues/2632
 func bytesToString(b *[]byte) string {
-  return *(*string)(unsafe.Pointer(b))
+	return *(*string)(unsafe.Pointer(b))
 }

--- a/escape.go
+++ b/escape.go
@@ -1,0 +1,152 @@
+package jsonparser
+
+import (
+	"bytes"
+	"unicode/utf8"
+)
+
+// JSON Unicode stuff: see https://tools.ietf.org/html/rfc7159#section-7
+
+const supplementalPlanesOffset = 0x10000
+const highSurrogateOffset = 0xD800
+const lowSurrogateOffset = 0xDC00
+
+func combineUTF16Surrogates(high, low rune) rune {
+	return supplementalPlanesOffset + (high-highSurrogateOffset)<<10 + (low - lowSurrogateOffset)
+}
+
+const badHex = -1
+
+func h2I(c byte) int {
+	switch {
+	case c >= '0' && c <= '9':
+		return int(c - '0')
+	case c >= 'A' && c <= 'F':
+		return int(c - 'A' + 10)
+	case c >= 'a' && c <= 'f':
+		return int(c - 'a' + 10)
+	}
+	return badHex
+}
+
+// decodeSingleUnicodeEscape decodes a single \uXXXX escape sequence. The prefix \u is assumed to be present and
+// is not checked.
+// In JSON, these escapes can either come alone or as part of "UTF16 surrogate pairs" that must be handled together.
+// This function only handles one; decodeUnicodeEscape handles this more complex case.
+func decodeSingleUnicodeEscape(in []byte) (rune, bool) {
+	// We need at least 6 characters total
+	if len(in) < 6 {
+		return utf8.RuneError, false
+	}
+
+	// Convert hex to decimal
+	h1, h2, h3, h4 := h2I(in[2]), h2I(in[3]), h2I(in[4]), h2I(in[5])
+	if h1 == badHex || h2 == badHex || h3 == badHex || h4 == badHex {
+		return utf8.RuneError, false
+	}
+
+	// Compose the hex digits
+	return rune(h1<<12 + h2<<8 + h3<<4 + h4), true
+}
+
+func decodeUnicodeEscape(in []byte) (rune, int) {
+	if r, ok := decodeSingleUnicodeEscape(in); !ok {
+		// Invalid Unicode escape
+		return utf8.RuneError, -1
+	} else if r < highSurrogateOffset {
+		// Valid Unicode escape in Basic Multilingual Plane
+		return r, 6
+	} else if r2, ok := decodeSingleUnicodeEscape(in[6:]); !ok { // Note: previous decodeSingleUnicodeEscape success guarantees at least 6 bytes remain
+		// UTF16 "high surrogate" without manditory valid following Unicode escape for the "low surrogate"
+		return utf8.RuneError, -1
+	} else if r2 < lowSurrogateOffset {
+		// Invalid UTF16 "low surrogate"
+		return utf8.RuneError, -1
+	} else {
+		// Valid UTF16 surrogate pair
+		return combineUTF16Surrogates(r, r2), 12
+	}
+
+}
+
+// unescapeToUTF8 unescapes the single escape sequence starting at 'in' into 'out' and returns
+// how many characters were consumed from 'in' and emitted into 'out'.
+// If a valid escape sequence does not appear as a prefix of 'in', (-1, -1) to signal the error.
+func unescapeToUTF8(in, out []byte) (inLen int, outLen int) {
+	if len(in) < 2 || in[0] != '\\' {
+		// Invalid escape due to insufficient characters for any escape or no initial backslash
+		return -1, -1
+	}
+
+	// https://tools.ietf.org/html/rfc7159#section-7
+	switch e := in[1]; e {
+	case '"', '\\', 'n', 't', 'r', '/', 'b', 'f':
+		// Valid basic 2-character escapes
+		out[0] = e
+		return 2, 1
+	case 'u':
+		// Unicode escape
+		if r, inLen := decodeUnicodeEscape(in); inLen == -1 {
+			// Invalid Unicode escape
+			return -1, -1
+		} else {
+			// Valid Unicode escape; re-encode as UTF8
+			outLen := utf8.EncodeRune(out, r)
+			return inLen, outLen
+		}
+	}
+
+	return -1, -1
+}
+
+// unescape unescapes the string contained in 'in' and returns it as a slice.
+// If 'in' contains no escaped characters:
+//   Returns 'in'.
+// Else, if 'out' is of sufficient capacity (guaranteed if cap(out) >= len(in)):
+//   'out' is used to build the unescaped string and is returned with no extra allocation
+// Else:
+//   A new slice is allocated and returned.
+func Unescape(in, out []byte) ([]byte, error) {
+	firstBackslash := bytes.IndexByte(in, '\\')
+	if firstBackslash == -1 {
+		return in, nil
+	}
+
+	// Get a buffer of sufficient size (allocate if needed)
+	if cap(out) < len(in) {
+		out = make([]byte, len(in))
+	} else {
+		out = out[0:len(in)]
+	}
+
+	// Copy the first sequence of unescaped bytes to the output and obtain a buffer pointer (subslice)
+	copy(out, in[:firstBackslash])
+	in = in[firstBackslash:]
+	buf := out[firstBackslash:]
+
+	for len(in) > 0 {
+		// Unescape the next escaped character
+		inLen, bufLen := unescapeToUTF8(in, buf)
+		if inLen == -1 {
+			return nil, MalformedStringEscapeError
+		}
+
+		in = in[inLen:]
+		buf = buf[bufLen:]
+
+		// Copy everything up until the next backslash
+		nextBackslash := bytes.IndexByte(in, '\\')
+		if nextBackslash == -1 {
+			copy(buf, in)
+			buf = buf[len(in):]
+			break
+		} else {
+			copy(buf, in[:nextBackslash])
+			buf = buf[nextBackslash:]
+			in = in[nextBackslash:]
+		}
+	}
+
+	// Trim the out buffer to the amount that was actually emitted
+	return out[:len(out)-len(buf)], nil
+}

--- a/escape_test.go
+++ b/escape_test.go
@@ -1,0 +1,189 @@
+package jsonparser
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestH2I(t *testing.T) {
+	hexChars := []byte{'0', '9', 'A', 'F', 'a', 'f', 'x', '\000'}
+	hexValues := []int{0, 9, 10, 15, 10, 15, -1, -1}
+
+	for i, c := range hexChars {
+		if v := h2I(c); v != hexValues[i] {
+			t.Errorf("h2I('%c') returned wrong value (obtained %d, expected %d)", c, v, hexValues[i])
+		}
+	}
+}
+
+type escapedUnicodeRuneTest struct {
+	in    string
+	isErr bool
+	out   rune
+	len   int
+}
+
+var commonUnicodeEscapeTests = []escapedUnicodeRuneTest{
+	{in: `\u0041`, out: 'A', len: 6},
+	{in: `\u0000`, out: 0, len: 6},
+	{in: `\u00b0`, out: '°', len: 6},
+	{in: `\u00B0`, out: '°', len: 6},
+
+	{in: `\x1234`, out: 0x1234, len: 6}, // These functions do not check the \u prefix
+
+	{in: ``, isErr: true},
+	{in: `\`, isErr: true},
+	{in: `\u`, isErr: true},
+	{in: `\u1`, isErr: true},
+	{in: `\u11`, isErr: true},
+	{in: `\u111`, isErr: true},
+	{in: `\u123X`, isErr: true},
+}
+
+var singleUnicodeEscapeTests = append([]escapedUnicodeRuneTest{
+	{in: `\uD83D`, out: 0xD83D, len: 6},
+	{in: `\uDE03`, out: 0xDE03, len: 6},
+	{in: `\uFFFF`, out: 0xFFFF, len: 6},
+}, commonUnicodeEscapeTests...)
+
+var multiUnicodeEscapeTests = append([]escapedUnicodeRuneTest{
+	{in: `\uD83D`, isErr: true},
+	{in: `\uDE03`, isErr: true},
+	{in: `\uFFFF`, isErr: true},
+
+	{in: `\uD83D\uDE03`, out: '\U0001F603', len: 12},
+	{in: `\uD800\uDC00`, out: '\U00010000', len: 12},
+
+	{in: `\uD800\`, isErr: true},
+	{in: `\uD800\u`, isErr: true},
+	{in: `\uD800\uD`, isErr: true},
+	{in: `\uD800\uDC`, isErr: true},
+	{in: `\uD800\uDC0`, isErr: true},
+	{in: `\uD800\uDBFF`, isErr: true}, // invalid low surrogate
+}, commonUnicodeEscapeTests...)
+
+func TestDecodeSingleUnicodeEscape(t *testing.T) {
+	for _, test := range singleUnicodeEscapeTests {
+		r, ok := decodeSingleUnicodeEscape([]byte(test.in))
+		isErr := !ok
+
+		if isErr != test.isErr {
+			t.Errorf("decodeSingleUnicodeEscape(%s) returned isErr mismatch: expected %t, obtained %t", test.in, test.isErr, isErr)
+		} else if isErr {
+			continue
+		} else if r != test.out {
+			t.Errorf("decodeSingleUnicodeEscape(%s) returned rune mismatch: expected %x (%c), obtained %x (%c)", test.in, test.out, test.out, r, r)
+		}
+	}
+}
+
+func TestDecodeUnicodeEscape(t *testing.T) {
+	for _, test := range multiUnicodeEscapeTests {
+		r, len := decodeUnicodeEscape([]byte(test.in))
+		isErr := (len == -1)
+
+		if isErr != test.isErr {
+			t.Errorf("decodeUnicodeEscape(%s) returned isErr mismatch: expected %t, obtained %t", test.in, test.isErr, isErr)
+		} else if isErr {
+			continue
+		} else if len != test.len {
+			t.Errorf("decodeUnicodeEscape(%s) returned length mismatch: expected %d, obtained %d", test.in, test.len, len)
+		} else if r != test.out {
+			t.Errorf("decodeUnicodeEscape(%s) returned rune mismatch: expected %x (%c), obtained %x (%c)", test.in, test.out, test.out, r, r)
+		}
+	}
+}
+
+type unescapeTest struct {
+	in       string // escaped string
+	out      string // expected unescaped string
+	canAlloc bool   // can unescape cause an allocation (depending on buffer size)? true iff 'in' contains escape sequence(s)
+	isErr    bool   // should this operation result in an error
+}
+
+var unescapeTests = []unescapeTest{
+	{in: ``, out: ``, canAlloc: false},
+	{in: `a`, out: `a`, canAlloc: false},
+	{in: `abcde`, out: `abcde`, canAlloc: false},
+
+	{in: `ab\\de`, out: `ab\de`, canAlloc: true},
+	{in: `ab\"de`, out: `ab"de`, canAlloc: true},
+	{in: `ab \u00B0 de`, out: `ab ° de`, canAlloc: true},
+	{in: `ab \uD83D\uDE03 de`, out: "ab \U0001F603 de", canAlloc: true},
+	{in: `\u0000\u0000\u0000\u0000\u0000`, out: "\u0000\u0000\u0000\u0000\u0000", canAlloc: true},
+	{in: `\u0000 \u0000 \u0000 \u0000 \u0000`, out: "\u0000 \u0000 \u0000 \u0000 \u0000", canAlloc: true},
+	{in: ` \u0000 \u0000 \u0000 \u0000 \u0000 `, out: " \u0000 \u0000 \u0000 \u0000 \u0000 ", canAlloc: true},
+
+	{in: `\uD800`, isErr: true},
+	{in: `\uFFFF`, isErr: true},
+	{in: `abcde\`, isErr: true},
+	{in: `abcde\x`, isErr: true},
+	{in: `abcde\u`, isErr: true},
+	{in: `abcde\u1`, isErr: true},
+	{in: `abcde\u12`, isErr: true},
+	{in: `abcde\u123`, isErr: true},
+	{in: `abcde\uD800`, isErr: true},
+	{in: `ab\uD800de`, isErr: true},
+	{in: `\uD800abcde`, isErr: true},
+}
+
+// isSameMemory checks if two slices contain the same memory pointer (meaning one is a
+// subslice of the other, with possibly differing lengths/capacities).
+func isSameMemory(a, b []byte) bool {
+	if cap(a) == 0 || cap(b) == 0 {
+		return cap(a) == cap(b)
+	} else if a, b = a[:1], b[:1]; a[0] != b[0] {
+		return false
+	} else {
+		a[0]++
+		same := (a[0] == b[0])
+		a[0]--
+		return same
+	}
+
+}
+
+func TestUnescape(t *testing.T) {
+	for _, test := range unescapeTests {
+		type bufferTestCase struct {
+			buf        []byte
+			isTooSmall bool
+		}
+
+		var bufs []bufferTestCase
+
+		if len(test.in) == 0 {
+			// If the input string is length 0, only a buffer of size 0 is a meaningful test
+			bufs = []bufferTestCase{{nil, false}}
+		} else {
+			// For non-empty input strings, we can try several buffer sizes (0, len-1, len)
+			bufs = []bufferTestCase{
+				{nil, true},
+				{make([]byte, 0, len(test.in)-1), true},
+				{make([]byte, 0, len(test.in)), false},
+			}
+		}
+
+		for _, buftest := range bufs {
+			in := []byte(test.in)
+			buf := buftest.buf
+
+			out, err := Unescape(in, buf)
+			isErr := (err != nil)
+			isAlloc := !isSameMemory(out, in) && !isSameMemory(out, buf)
+
+			if isErr != test.isErr {
+				t.Errorf("Unescape(`%s`, bufsize=%d) returned isErr mismatch: expected %t, obtained %t", test.in, cap(buf), test.isErr, isErr)
+				break
+			} else if isErr {
+				continue
+			} else if !bytes.Equal(out, []byte(test.out)) {
+				t.Errorf("Unescape(`%s`, bufsize=%d) returned unescaped mismatch: expected `%s` (%v, len %d), obtained `%s` (%v, len %d)", test.in, cap(buf), test.out, []byte(test.out), len(test.out), string(out), out, len(out))
+				break
+			} else if isAlloc != (test.canAlloc && buftest.isTooSmall) {
+				t.Errorf("Unescape(`%s`, bufsize=%d) returned isAlloc mismatch: expected %t, obtained %t", test.in, cap(buf), buftest.isTooSmall, isAlloc)
+				break
+			}
+		}
+	}
+}

--- a/parser.go
+++ b/parser.go
@@ -9,13 +9,14 @@ import (
 
 // Errors
 var (
-	KeyPathNotFoundError  = errors.New("Key path not found")
-	UnknownValueTypeError = errors.New("Unknown value type")
-	MalformedJsonError    = errors.New("Malformed JSON error")
-	MalformedStringError  = errors.New("Value is string, but can't find closing '\"' symbol")
-	MalformedArrayError   = errors.New("Value is array, but can't find closing ']' symbol")
-	MalformedObjectError  = errors.New("Value looks like object, but can't find closing '}' symbol")
-	MalformedValueError   = errors.New("Value looks like Number/Boolean/None, but can't find its end: ',' or '}' symbol")
+	KeyPathNotFoundError       = errors.New("Key path not found")
+	UnknownValueTypeError      = errors.New("Unknown value type")
+	MalformedJsonError         = errors.New("Malformed JSON error")
+	MalformedStringError       = errors.New("Value is string, but can't find closing '\"' symbol")
+	MalformedArrayError        = errors.New("Value is array, but can't find closing ']' symbol")
+	MalformedObjectError       = errors.New("Value looks like object, but can't find closing '}' symbol")
+	MalformedValueError        = errors.New("Value looks like Number/Boolean/None, but can't find its end: ',' or '}' symbol")
+	MalformedStringEscapeError = errors.New("Encountered an invalid escape sequence in a string")
 )
 
 func tokenEnd(data []byte) int {

--- a/parser.go
+++ b/parser.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"strconv"
 )
 
 // Errors
@@ -18,6 +17,10 @@ var (
 	MalformedValueError        = errors.New("Value looks like Number/Boolean/None, but can't find its end: ',' or '}' symbol")
 	MalformedStringEscapeError = errors.New("Encountered an invalid escape sequence in a string")
 )
+
+// How much stack space to allocate for unescaping JSON strings; if a string longer
+// than this needs to be escaped, it will result in a heap allocation
+const unescapeStackBufSize = 64
 
 func tokenEnd(data []byte) int {
 	for i, c := range data {
@@ -46,24 +49,32 @@ func nextToken(data []byte) int {
 
 // Tries to find the end of string
 // Support if string contains escaped quote symbols.
-func stringEnd(data []byte) int {
+func stringEnd(data []byte) (int, bool) {
+	escaped := false
 	for i, c := range data {
 		if c == '"' {
-			j := i - 1
-			for {
-				if j < 0 || data[j] != '\\' {
-					return i + 1 // even number of backslashes
+			if !escaped {
+				return i + 1, false
+			} else {
+				j := i - 1
+				for {
+					if j < 0 || data[j] != '\\' {
+						return i + 1, true // even number of backslashes
+					}
+					j--
+					if j < 0 || data[j] != '\\' {
+						break // odd number of backslashes
+					}
+					j--
+
 				}
-				j--
-				if j < 0 || data[j] != '\\' {
-					break // odd number of backslashes
-				}
-				j--
 			}
+		} else if c == '\\' {
+			escaped = true
 		}
 	}
 
-	return -1
+	return -1, escaped
 }
 
 // Find end of the data structure, array or object.
@@ -76,7 +87,7 @@ func blockEnd(data []byte, openSym byte, closeSym byte) int {
 	for i < ln {
 		switch data[i] {
 		case '"': // If inside string, skip it
-			se := stringEnd(data[i+1:])
+			se, _ := stringEnd(data[i+1:])
 			if se == -1 {
 				return -1
 			}
@@ -104,13 +115,15 @@ func searchKeys(data []byte, keys ...string) int {
 	ln := len(data)
 	lk := len(keys)
 
+	var stackbuf [unescapeStackBufSize]byte // stack-allocated array for allocation-free unescaping of small strings
+
 	for i < ln {
 		switch data[i] {
 		case '"':
 			i++
 			keyBegin := i
 
-			strEnd := stringEnd(data[i:])
+			strEnd, keyEscaped := stringEnd(data[i:])
 			if strEnd == -1 {
 				return -1
 			}
@@ -124,12 +137,22 @@ func searchKeys(data []byte, keys ...string) int {
 
 			i += valueOffset
 
-			// if string is a Key, and key level match
-			if data[i] == ':' {
+			// if string is a key, and key level match
+			if data[i] == ':' && keyLevel == level-1 {
 				key := data[keyBegin:keyEnd]
 
-				if keyLevel == level-1 && // If key nesting level match current object nested level
-					equalStr(&key, keys[level-1]) {
+				// for unescape: if there are no escape sequences, this is cheap; if there are, it is a
+				// bit more expensive, but causes no allocations unless len(key) > unescapeStackBufSize
+				var keyUnesc []byte
+				if !keyEscaped {
+					keyUnesc = key
+				} else if ku, err := Unescape(key, stackbuf[:]); err != nil {
+					return -1
+				} else {
+					keyUnesc = ku
+				}
+
+				if equalStr(&keyUnesc, keys[level-1]) {
 					keyLevel++
 					// If we found all keys in path
 					if keyLevel == lk {
@@ -206,7 +229,7 @@ func Get(data []byte, keys ...string) (value []byte, dataType ValueType, offset 
 	// if string value
 	if data[offset] == '"' {
 		dataType = String
-		if idx := stringEnd(data[offset+1:]); idx != -1 {
+		if idx, _ := stringEnd(data[offset+1:]); idx != -1 {
 			endOffset += idx + 1
 		} else {
 			return []byte{}, dataType, offset, MalformedStringError
@@ -371,9 +394,10 @@ func GetString(data []byte, keys ...string) (val string, err error) {
 		return string(v), nil
 	}
 
-	s, err := strconv.Unquote(`"` + string(v) + `"`)
+	var stackbuf [unescapeStackBufSize]byte // stack-allocated array for allocation-free unescaping of small strings
+	out, err := Unescape(v, stackbuf[:])
 
-	return s, err
+	return string(out), err
 }
 
 // GetFloat returns the value retrieved by `Get`, cast to a float64 if possible.

--- a/parser_test.go
+++ b/parser_test.go
@@ -158,6 +158,30 @@ var getTests = []Test{
 		isFound: true,
 		data:    `3`,
 	},
+
+	// Escaped key tests
+	Test{
+		desc:    `key with simple escape`,
+		json:    `{"a\\b":1}`,
+		path:    []string{"a\\b"},
+		isFound: true,
+		data:    `1`,
+	},
+	Test{
+		desc:    `key with Unicode escape`,
+		json:    `{"a\u00B0b":1}`,
+		path:    []string{"a\u00B0b"},
+		isFound: true,
+		data:    `1`,
+	},
+	Test{
+		desc:    `key with complex escape`,
+		json:    `{"a\uD83D\uDE03b":1}`,
+		path:    []string{"a\U0001F603b"},
+		isFound: true,
+		data:    `1`,
+	},
+
 	Test{ // This test returns a match instead of a parse error, as checking for the malformed JSON would reduce performance
 		desc:    `malformed with trailing whitespace`,
 		json:    `{"a":1 `,
@@ -268,6 +292,7 @@ var getTests = []Test{
 		path:  []string{"a"},
 		isErr: true,
 	},
+
 	Test{ // This test returns not found instead of a parse error, as checking for the malformed JSON would reduce performance
 		desc:  "malformed key (followed by comma followed by colon)",
 		json:  `{"a",:1}`,
@@ -326,18 +351,25 @@ var getFloatTests = []Test{
 
 var getStringTests = []Test{
 	Test{
-		desc:    `Translate unicode symbols`,
+		desc:    `Translate Unicode symbols`,
 		json:    `{"c": "test"}`,
 		path:    []string{"c"},
 		isFound: true,
 		data:    `test`,
 	},
 	Test{
-		desc:    `Translate unicode symbols`,
+		desc:    `Translate Unicode symbols`,
 		json:    `{"c": "15\u00b0C"}`,
 		path:    []string{"c"},
 		isFound: true,
 		data:    `15°C`,
+	},
+	Test{
+		desc:    `Translate supplementary Unicode symbols`,
+		json:    `{"c": "\uD83D\uDE03"}`, // Smiley face (UTF16 surrogate pair)
+		path:    []string{"c"},
+		isFound: true,
+		data:    "\U0001F603", // Smiley face
 	},
 	Test{
 		desc:    `Translate escape symbols`,


### PR DESCRIPTION
Added proper JSON escaped string handling in both keys and values (as per [RFC 7159](https://tools.ietf.org/html/rfc7159)). These changes necessarily resulted in some performance degradation, but it's relatively minor (< 10%, it seems).

(Note: this is a refinement of #39)

*Benchmark before:*
```
BenchmarkJsonParserLarge-8 	 	     64506 ns/op	       0 allocs/op
BenchmarkJsonParserMedium-8	 	     10865 ns/op	       0 allocs/op
BenchmarkJsonParserSmall-8 		      1026 ns/op	       0 allocs/op
```

*Benchmark after:*
```
BenchmarkJsonParserLarge-8 	  	     66558 ns/op	       0 allocs/op
BenchmarkJsonParserMedium-8	 	     11958 ns/op	       0 allocs/op
BenchmarkJsonParserSmall-8 		      1061 ns/op	       0 allocs/op
```