### PR TITLE
Add EachKey

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 SOURCE = parser.go
 CONTAINER = jsonparser
 SOURCE_PATH = /go/src/github.com/buger/jsonparser
-BENCHMARK = BenchmarkJsonParserEachKeyManualMedium
+BENCHMARK = JsonParser
 BENCHTIME = 5s
-TEST = TestEachKey
+TEST = .
 DRUN = docker run -v `pwd`:$(SOURCE_PATH) -i -t $(CONTAINER)
 
 build:

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 SOURCE = parser.go
 CONTAINER = jsonparser
 SOURCE_PATH = /go/src/github.com/buger/jsonparser
-BENCHMARK = JsonParserSmall
+BENCHMARK = BenchmarkJsonParserEachKeyManualMedium
 BENCHTIME = 5s
-TEST = .
+TEST = TestEachKey
 DRUN = docker run -v `pwd`:$(SOURCE_PATH) -i -t $(CONTAINER)
 
 build:

--- a/benchmark/benchmark_medium_payload_test.go
+++ b/benchmark/benchmark_medium_payload_test.go
@@ -34,6 +34,32 @@ func BenchmarkJsonParserMedium(b *testing.B) {
 	}
 }
 
+func BenchmarkJsonParserEachKeyManualMedium(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		paths := [][]string{
+			[]string{"person", "name", "fullName"},
+			[]string{"person", "github", "followers"},
+			[]string{"company"},
+			[]string{"person", "gravatar", "avatars"},
+		}
+
+		jsonparser.EachKey(mediumFixture, func(idx int, value []byte, vt jsonparser.ValueType, err error){
+			switch idx {
+			case 0:
+				// jsonparser.ParseString(value)
+			case 1:
+				jsonparser.ParseInt(value)
+			case 2:
+				// jsonparser.ParseString(value)
+			case 3:
+				jsonparser.ArrayEach(value, func(avalue []byte, dataType jsonparser.ValueType, offset int, err error) {
+					jsonparser.Get(avalue, "url")
+				})
+			}
+		}, paths...)
+	}
+}
+
 /*
    encoding/json
 */

--- a/benchmark/benchmark_small_payload_test.go
+++ b/benchmark/benchmark_small_payload_test.go
@@ -35,6 +35,60 @@ func BenchmarkJsonParserSmall(b *testing.B) {
 	}
 }
 
+func BenchmarkJsonParserEachKeyManualSmall(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		paths := [][]string{
+			[]string{"uuid"},
+			[]string{"tz"},
+			[]string{"ua"},
+			[]string{"st"},
+		}
+
+		jsonparser.EachKey(smallFixture, func(idx int, value []byte, vt jsonparser.ValueType, err error){
+			switch idx {
+			case 0:
+				// jsonparser.ParseString(value)
+			case 1:
+				jsonparser.ParseInt(value)
+			case 2:
+				// jsonparser.ParseString(value)
+			case 3:
+				jsonparser.ParseInt(value)
+			}
+		}, paths...)
+	}
+}
+
+
+func BenchmarkJsonParserEachKeyStructSmall(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		paths := [][]string{
+			[]string{"uuid"},
+			[]string{"tz"},
+			[]string{"ua"},
+			[]string{"st"},
+		}
+		var data SmallPayload
+
+		jsonparser.EachKey(smallFixture, func(idx int, value []byte, vt jsonparser.ValueType, err error){
+			switch idx {
+			case 0:
+				data.Uuid, _ = jsonparser.ParseString(value)
+			case 1:
+				v, _ := jsonparser.ParseInt(value)
+				data.Tz = int(v)
+			case 2:
+				data.Ua, _ = jsonparser.ParseString(value)
+			case 3:
+				v, _ := jsonparser.ParseInt(value)
+				data.St = int(v)
+			}
+		}, paths...)
+
+		nothing(data.Uuid, data.Tz, data.Ua, data.St)
+	}
+}
+
 /*
    encoding/json
 */

--- a/parser_test.go
+++ b/parser_test.go
@@ -627,3 +627,40 @@ func TestArrayEach(t *testing.T) {
 		}
 	}, "a", "b")
 }
+
+var testJson = []byte(`{"name": "Name", "order": "Order", "sum": 100, "len": 12, "isPaid": true, "nested": {"a":"test", "b":2, "nested3":{"a":"test3","b":4}, "c": "unknown"}, "nested2": {"a":"test2", "b":3}, "arr": [{"a":"zxc", "b": 1}, {"a":"123", "b":2}], "arrInt": [1,2,3,4], "intPtr": 10}`)
+
+func TestEachKey(t *testing.T) {
+	paths := [][]string{
+		[]string{"name"},
+		[]string{"nested", "a"},
+		[]string{"nested", "nested3", "b"},
+	}
+
+	keysFound := 0
+
+	EachKey(testJson, func(idx int, value []byte, vt ValueType, err error){
+		keysFound++
+
+		switch idx {
+		case 0:
+			if string(value) != "Name" {
+				t.Errorf("Should find 1 key")
+			}
+		case 1:
+			if string(value) != "test" {
+				t.Errorf("Should find 2 key")
+			}
+		case 2:
+			if string(value) != "4" {
+				t.Errorf("Should find 3 key")
+			}
+		default:
+			t.Errorf("Should found only 3 keys")
+		}
+	}, paths...)
+
+	if keysFound != 3 {
+		t.Errorf("Should find 3 keys: %d", keysFound)
+	}
+}


### PR DESCRIPTION
**Description**:
Fetch multiple keys at once. Instead of reading whole payload for each key, it does read only 1 time.

Using new API you can get nearly 2x improvement when fetching multiple keys, and the more keys you fetch, the bigger difference. 

Example:

```go
paths := [][]string{
	[]string{"uuid"},
	[]string{"tz"},
	[]string{"ua"},
	[]string{"st"},
}

jsonparser.EachKey(smallFixture, func(idx int, value []byte, vt jsonparser.ValueType, err error){
	switch idx {
	case 0: // uuid
		// jsonparser.ParseString(value)
	case 1: // tz
		jsonparser.ParseInt(value)
	case 2: // ua
		// jsonparser.ParseString(value)
	case 3: //sa
		jsonparser.ParseInt(value)
	}
}, paths...)
```

**Benchmark before change**:
```
BenchmarkJsonParserLarge 	  100000	     84621 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserMedium	  500000	     15803 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserSmall 	 5000000	      1378 ns/op	       0 B/op	       0 allocs/op
```

**Added 2 new benchmarks**:
```
BenchmarkJsonParserEachKeyManualMedium	 1000000	      8312 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualSmall 	10000000	       798 ns/op	       0 B/op	       0 allocs/op
```