### PR TITLE
Fixed some two-character escapes like \n not escaping right

### DIFF
--- a/escape.go
+++ b/escape.go
@@ -69,6 +69,18 @@ func decodeUnicodeEscape(in []byte) (rune, int) {
 
 }
 
+// backslashCharEscapeTable: when '\X' is found for some byte X, it is to be replaced with backslashCharEscapeTable[X]
+var backslashCharEscapeTable = [...]byte{
+	'"':  '"',
+	'\\': '\\',
+	'/':  '/',
+	'b':  '\b',
+	'f':  '\f',
+	'n':  '\n',
+	'r':  '\r',
+	't':  '\t',
+}
+
 // unescapeToUTF8 unescapes the single escape sequence starting at 'in' into 'out' and returns
 // how many characters were consumed from 'in' and emitted into 'out'.
 // If a valid escape sequence does not appear as a prefix of 'in', (-1, -1) to signal the error.
@@ -80,9 +92,9 @@ func unescapeToUTF8(in, out []byte) (inLen int, outLen int) {
 
 	// https://tools.ietf.org/html/rfc7159#section-7
 	switch e := in[1]; e {
-	case '"', '\\', 'n', 't', 'r', '/', 'b', 'f':
-		// Valid basic 2-character escapes
-		out[0] = e
+	case '"', '\\', '/', 'b', 'f', 'n', 'r', 't':
+		// Valid basic 2-character escapes (use lookup table)
+		out[0] = backslashCharEscapeTable[e]
 		return 2, 1
 	case 'u':
 		// Unicode escape

--- a/parser_test.go
+++ b/parser_test.go
@@ -168,6 +168,13 @@ var getTests = []GetTest{
 		data:    `1`,
 	},
 	GetTest{
+		desc:    `key and value with whitespace escapes`,
+		json:    `{"key\b\f\n\r\tkey":"value\b\f\n\r\tvalue"}`,
+		path:    []string{"key\b\f\n\r\tkey"},
+		isFound: true,
+		data:    `value\b\f\n\r\tvalue`, // value is not unescaped since this is Get(), but the key should work correctly
+	},
+	GetTest{
 		desc:    `key with Unicode escape`,
 		json:    `{"a\u00B0b":1}`,
 		path:    []string{"a\u00B0b"},
@@ -370,6 +377,13 @@ var getStringTests = []GetTest{
 		path:    []string{"c"},
 		isFound: true,
 		data:    `\"`,
+	},
+	GetTest{
+		desc:    `key and value with whitespace escapes`,
+		json:    `{"key\b\f\n\r\tkey":"value\b\f\n\r\tvalue"}`,
+		path:    []string{"key\b\f\n\r\tkey"},
+		isFound: true,
+		data:    "value\b\f\n\r\tvalue", // value is unescaped since this is GetString()
 	},
 }
 


### PR DESCRIPTION
Fixes #49 and adds tests to actually test escaped whitespace in keys/values.