### PR TITLE
Bugfix searchKeys for malformed JSON arrays

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -169,8 +169,11 @@ func searchKeys(data []byte, keys ...string) int {
 			level--
 		case '[':
 			// Do not search for keys inside arrays
-			arraySkip := blockEnd(data[i:], '[', ']')
-			i += arraySkip - 1
+			if arraySkip := blockEnd(data[i:], '[', ']'); arraySkip == -1 {
+				return -1
+			} else {
+				i += arraySkip - 1
+			}
 		}
 
 		i++

--- a/parser_test.go
+++ b/parser_test.go
@@ -292,6 +292,12 @@ var getTests = []GetTest{
 		path:  []string{"a"},
 		isErr: true,
 	},
+	GetTest{
+		desc:  `malformed array (no closing brace)`,
+		json:  `{"a":[, "b":123}`,
+		path:  []string{"b"},
+		isErr: true,
+	},
 
 	GetTest{ // This test returns not found instead of a parse error, as checking for the malformed JSON would reduce performance
 		desc:  "malformed key (followed by comma followed by colon)",


### PR DESCRIPTION
Fixed an infinite loop in `searchKeys` in the presence of an unclose JSON array. There may be similar bug(s) in `KeyEach`, maybe you can check @buger?