### PR TITLE
Add ObjectEach() for iterating over object key-value pairs

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -540,6 +540,113 @@ func ArrayEach(data []byte, cb func(value []byte, dataType ValueType, offset int
 	return nil
 }
 
+// ObjectEach iterates over the key-value pairs of a JSON object, invoking a given callback for each such entry
+func ObjectEach(data []byte, callback func(key []byte, value []byte, dataType ValueType, offset int) error, keys ...string) (err error) {
+	var stackbuf [unescapeStackBufSize]byte // stack-allocated array for allocation-free unescaping of small strings
+	offset := 0
+
+	// Descend to the desired key, if requested
+	if len(keys) > 0 {
+		if off := searchKeys(data, keys...); off == -1 {
+			return KeyPathNotFoundError
+		} else {
+			offset = off
+		}
+	}
+
+	// Validate and skip past opening brace
+	if off := nextToken(data[offset:]); off == -1 {
+		return MalformedObjectError
+	} else if offset += off; data[offset] != '{' {
+		return MalformedObjectError
+	} else {
+		offset++
+	}
+
+	// Skip to the first token inside the object, or stop if we find the ending brace
+	if off := nextToken(data[offset:]); off == -1 {
+		return MalformedJsonError
+	} else if offset += off; data[offset] == '}' {
+		return nil
+	}
+
+	// Loop pre-condition: data[offset] points to what should be either the next entry's key, or the closing brace (if it's anything else, the JSON is malformed)
+	for offset < len(data) {
+		// Step 1: find the next key
+		var key []byte
+
+		// Check what the the next token is: start of string, end of object, or something else (error)
+		switch data[offset] {
+		case '"':
+			offset++ // accept as string and skip opening quote
+		case '}':
+			return nil // we found the end of the object; stop and return success
+		default:
+			return MalformedObjectError
+		}
+
+		// Find the end of the key string
+		var keyEscaped bool
+		if off, esc := stringEnd(data[offset:]); off == -1 {
+			return MalformedJsonError
+		} else {
+			key, keyEscaped = data[offset:offset+off-1], esc
+			offset += off
+		}
+
+		// Unescape the string if needed
+		if keyEscaped {
+			if keyUnescaped, err := Unescape(key, stackbuf[:]); err != nil {
+				return MalformedStringEscapeError
+			} else {
+				key = keyUnescaped
+			}
+		}
+
+		// Step 2: skip the colon
+		if off := nextToken(data[offset:]); off == -1 {
+			return MalformedJsonError
+		} else if offset += off; data[offset] != ':' {
+			return MalformedJsonError
+		} else {
+			offset++
+		}
+
+		// Step 3: find the associated value, then invoke the callback
+		if value, valueType, off, err := Get(data[offset:]); err != nil {
+			return err
+		} else if err := callback(key, value, valueType, offset+off); err != nil { // Invoke the callback here!
+			return err
+		} else {
+			offset += off
+		}
+
+		// Step 4: skip over the next comma to the following token, or stop if we hit the ending brace
+		if off := nextToken(data[offset:]); off == -1 {
+			return MalformedArrayError
+		} else {
+			offset += off
+			switch data[offset] {
+			case '}':
+				return nil // Stop if we hit the close brace
+			case ',':
+				offset++ // Ignore the comma
+			default:
+				return MalformedObjectError
+			}
+		}
+
+		// Skip to the next token after the comma
+		if off := nextToken(data[offset:]); off == -1 {
+			return MalformedArrayError
+		} else {
+			offset += off
+		}
+	}
+
+	return MalformedObjectError // we shouldn't get here; it's expected that we will return via finding the ending brace
+}
+
 // GetUnsafeString returns the value retrieved by `Get`, use creates string without memory allocation by mapping string to slice memory. It does not handle escape symbols.
 func GetUnsafeString(data []byte, keys ...string) (val string, err error) {
 	v, _, _, e := Get(data, keys...)

--- a/parser.go
+++ b/parser.go
@@ -346,6 +346,27 @@ const (
 	Unknown
 )
 
+func (vt ValueType) String() string {
+	switch vt {
+	case NotExist:
+		return "non-existent"
+	case String:
+		return "string"
+	case Number:
+		return "number"
+	case Object:
+		return "object"
+	case Array:
+		return "array"
+	case Boolean:
+		return "boolean"
+	case Null:
+		return "null"
+	default:
+		return "unknown"
+	}
+}
+
 var (
 	trueLiteral  = []byte("true")
 	falseLiteral = []byte("false")


### PR DESCRIPTION
This PR implements the `ObjectEach` function to iterate over the key-value pairs of a JSON object. Its signature is as follows:

```
ObjectEach(
  data []byte,
  callback func(key []byte, value []byte, valueType ValueType, offset int) error,
)
```

`ObjectEach` will invoke `callback` for each key-value pair in the JSON object contained in `data` as follows:
* `key` will be the _unescaped_ key string of the key-value pair
* `value` will be the raw bytes composing the value of the key-value pair (as if returned by `Get()`; quotes are stripped from strings, `null` is represented as an empty byte slice, and all other values are passed as their literal bytes)
* `valueType` is the JSON data type of `value`
* `offset` is the byte offset just past the end of the value of the key-value pair

If any invocation of `callback` returns a non-nil error, the iteration terminates and that error is returned from `ObjectEach` itself.

The name `ObjectEach` was chosen to mirror the analogous `ArrayEach`, which iterates over the elements of a JSON array with a callback.

Relevant benchmarks:
```
$ goapp test -bench "BenchmarkJsonParser.*Struct.*" -benchtime 10s -benchmem
BenchmarkJsonParserEachKeyStructMedium-8   	 1000000	     15307 ns/op	     544 B/op	      11 allocs/op
BenchmarkJsonParserObjectEachStructMedium-8	  500000	     23988 ns/op	     608 B/op	      12 allocs/op
BenchmarkJsonParserEachKeyStructSmall-8    	10000000	      2248 ns/op	     176 B/op	       7 allocs/op
BenchmarkJsonParserObjectEachStructSmall-8 	10000000	      2129 ns/op	     240 B/op	       8 allocs/op
```

The decreased performance seen on the `Medium` test is because `ObjectEach` double-parses some values.  For example, when looking up key `person.name.fullName`, `ObjectEach` visits the `name` key within `person`, which causes the value `{"fullName": ..., ... }` to be scanned to find its extent. Then, inside the callback (which receives the byte slice for the value of `name`), we call `GetString` to extract the value of `fullName` within this inner object, which scans that object a second time.

The bottom line is that `ObjectEach` seems very efficient when scanning a leaf object (i.e., an object whose values are primitives), or when the inner objects will not be accessed (it should be efficient at simply skipping object values), but there is some overhead when values that are objects will be accessed further; in this case, `EachKey` or simple `Get`s may be a better choice.