### PR TITLE
Removed special handling of 'null' value return

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -446,10 +446,6 @@ func Get(data []byte, keys ...string) (value []byte, dataType ValueType, offset 
 		value = value[1 : len(value)-1]
 	}
 
-	if dataType == Null {
-		value = []byte{}
-	}
-
 	return value, dataType, endOffset, nil
 }
 


### PR DESCRIPTION
This PR removes the special case for when `null` is found by `Get()`. Previously, a new, empty slice was allocated to return (via `[]byte{}`), which allocates memory (abeit a very small amount) and gives `null` a special behavior (as opposed to `true` and `false`, which return a byte slice containing the literal keyword. Let's just leave the return as the bytes `null`, instead.
