### PR TITLE
first crack at extracting values from arrays by giving an index as a …

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -176,29 +176,16 @@ func searchKeys(data []byte, keys ...string) int {
 					i++
 					level++
 					keyLevel++
-					for index > 0 {
-						_, _, o, e := Get(data[i:])
-						if o == 0 {
-							break
-						} else if e != nil {
-							return -1
-						}
-						i += o
-
-						if skipToToken := nextToken(data[i:]); skipToToken != -1 {
-							i += skipToToken
-							if data[i] == ']' {
-								break
-							} else if data[i] != ',' {
-								return -1
-							}
-							i++
+					ArrayEach(data[i-1:blockEnd(data[i-1:], '[', ']')-1], func(value []byte, dataType ValueType, offset int, err error) {
+						if index > 0 {
 							index--
-						} else {
-							return -1
+							if skipToToken := nextToken(data[i:]); skipToToken != -1 {
+								i += skipToToken
+							}
+							i += len(value)
+							i++
 						}
-					}
-					i += nextToken(data[i:])
+					}, make([]string, 0)...)
 					if index != 0 { // if keys have been looped through and array is smaller then expected return
 						return -1
 					} else if keyLevel == lk {

--- a/parser_test.go
+++ b/parser_test.go
@@ -77,18 +77,18 @@ var getTests = []GetTest{
 	GetTest{
 		desc: "key in path is index (formatted json)",
 		json: `{
-                    "a": [
-                        {"b": 1},
-                        {"b": "2"},
-                        3
-                    ],
-                    "c": {
-                        "c": [
-                            1,
-                            2
-                        ]
-                    }
-                }`,
+		    "a": [
+			{"b": 1},
+			{"b": "2"},
+			3
+		    ],
+		    "c": {
+			"c": [
+			    1,
+			    2
+			]
+		    }
+		}`,
 		path:    []string{"a", "[0]", "b"},
 		isFound: true,
 		data:    `1`,

--- a/parser_test.go
+++ b/parser_test.go
@@ -40,8 +40,62 @@ type GetTest struct {
 var getTests = []GetTest{
 	// Found key tests
 	GetTest{
+		desc:    "last key in path is index",
+		json:    `{"a":[{"b":1},{"b":"2"}, 3],"c":{"c":[1,2]}}`,
+		path:    []string{"a", "[1]"},
+		isFound: true,
+		data:    `{"b":"2"}`,
+	},
+	GetTest{
+		desc:    "key in path is index",
+		json:    `{"a":[{"b":"1"},{"b":"2"},3],"c":{"c":[1,2]}}`,
+		path:    []string{"a", "[0]", "b"},
+		isFound: true,
+		data:    `1`,
+	},
+	GetTest{
+		desc: "last key in path is an index to value in array (formatted json)",
+		json: `{
+		    "a": [
+			{
+			    "b": 1
+			},
+			{"b":"2"},
+			3
+		    ],
+		    "c": {
+			"c": [
+			    1,
+			    2
+			]
+		    }
+		}`,
+		path:    []string{"a", "[1]"},
+		isFound: true,
+		data:    `{"b":"2"}`,
+	},
+	GetTest{
+		desc: "key in path is index (formatted json)",
+		json: `{
+                    "a": [
+                        {"b": 1},
+                        {"b": "2"},
+                        3
+                    ],
+                    "c": {
+                        "c": [
+                            1,
+                            2
+                        ]
+                    }
+                }`,
+		path:    []string{"a", "[0]", "b"},
+		isFound: true,
+		data:    `1`,
+	},
+	GetTest{
 		desc:    "handling multiple nested keys with same name",
-		json:    `{"a":[{"b":1},{"b":2},3],"c":{"c":[1,2]}} }`,
+		json:    `{"a":[{"b":1},{"b":2},3],"c":{"c":[1,2]}}`,
 		path:    []string{"c", "c"},
 		isFound: true,
 		data:    `[1,2]`,
@@ -76,7 +130,7 @@ var getTests = []GetTest{
 	},
 	GetTest{
 		desc:    `handle multiple nested keys with same name`,
-		json:    `{"a":[{"b":1},{"b":2},3],"c":{"c":[1,2]}} }`,
+		json:    `{"a":[{"b":1},{"b":2},3],"c":{"c":[1,2]}}`,
 		path:    []string{"c", "c"},
 		isFound: true,
 		data:    `[1,2]`,
@@ -642,7 +696,7 @@ func TestEachKey(t *testing.T) {
 
 	keysFound := 0
 
-	EachKey(testJson, func(idx int, value []byte, vt ValueType, err error){
+	EachKey(testJson, func(idx int, value []byte, vt ValueType, err error) {
 		keysFound++
 
 		switch idx {


### PR DESCRIPTION
**Description**: What this PR does
goal is to extract values from arrays nested in deeper structures and values from within those array values

an example is provided in the added test

**Benchmark before change**:

``` go
docker run -v `pwd`:/go/src/github.com/buger/jsonparser -i -t jsonparser go test  -test.benchmem -bench JsonParser ./benchmark/  -benchtime 5s -v
testing: warning: no tests to run
PASS
BenchmarkJsonParserLarge-2                         50000            182450 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserMedium-2                       200000             33686 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-2          500000             18086 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserSmall-2                       2000000              3361 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-2          5000000              1905 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyStructSmall-2          3000000              2776 ns/op             176 B/op          7 allocs/op
ok      github.com/buger/jsonparser/benchmark   59.980s

**Benchmark after change**:
docker run -v `pwd`:/go/src/github.com/buger/jsonparser -i -t jsonparser go test  -test.benchmem -bench JsonParser ./benchmark/  -benchtime 5s -v
testing: warning: no tests to run
PASS
BenchmarkJsonParserLarge-2                         50000            183814 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserMedium-2                       200000             34856 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-2          500000             17943 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserSmall-2                       2000000              3403 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-2          5000000              1877 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyStructSmall-2          3000000              2786 ns/op             176 B/op          7 allocs/op
ok      github.com/buger/jsonparser/benchmark   60.314s
```
