### PR TITLE
Fix parsing of values

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -31,7 +31,7 @@ func tokenEnd(data []byte) int {
 		}
 	}
 
-	return -1
+	return len(data)
 }
 
 // Find position of next character which is not whitespace

--- a/parser_test.go
+++ b/parser_test.go
@@ -39,6 +39,38 @@ type GetTest struct {
 }
 
 var getTests = []GetTest{
+	// Trivial tests
+	GetTest{
+		desc:    "read string",
+		json:    `""`,
+		isFound: true,
+		data:    ``,
+	},
+	GetTest{
+		desc:    "read number",
+		json:    `0`,
+		isFound: true,
+		data:    `0`,
+	},
+	GetTest{
+		desc:    "read object",
+		json:    `{}`,
+		isFound: true,
+		data:    `{}`,
+	},
+	GetTest{
+		desc:    "read array",
+		json:    `[]`,
+		isFound: true,
+		data:    `[]`,
+	},
+	GetTest{
+		desc:    "read boolean",
+		json:    `true`,
+		isFound: true,
+		data:    `true`,
+	},
+
 	// Found key tests
 	GetTest{
 		desc:    "handling multiple nested keys with same name",


### PR DESCRIPTION
**Description**: This fixes the problem that calling Get on simple values would fail:

```go
    data := []byte("0")
    value, dataType, offset, err := Get(data)
    // err == "Value looks like Number/Boolean/None, but can't find its end: ',' or '}' symbol"
```

**Benchmark before change**:
```
BenchmarkJsonParserLarge-4                    	  100000	     88822 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserMedium-4                   	  500000	     13879 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-4      	 1000000	      7999 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyStructMedium-4      	 1000000	      8586 ns/op	     544 B/op	      11 allocs/op
BenchmarkJsonParserObjectEachStructMedium-4   	  500000	     14922 ns/op	     608 B/op	      12 allocs/op
BenchmarkJsonParserSmall-4                    	 5000000	      1446 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-4       	10000000	       821 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyStructSmall-4       	10000000	      1184 ns/op	     176 B/op	       7 allocs/op
BenchmarkJsonParserObjectEachStructSmall-4    	10000000	      1118 ns/op	     240 B/op	       8 allocs/op
```

**Benchmark after change**:
```
BenchmarkJsonParserLarge-4                    	  100000	     89074 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserMedium-4                   	  500000	     13880 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-4      	 1000000	      8019 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyStructMedium-4      	 1000000	      8518 ns/op	     544 B/op	      11 allocs/op
BenchmarkJsonParserObjectEachStructMedium-4   	  500000	     13535 ns/op	     608 B/op	      12 allocs/op
BenchmarkJsonParserSmall-4                    	 5000000	      1390 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-4       	10000000	       975 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyStructSmall-4       	 5000000	      1205 ns/op	     176 B/op	       7 allocs/op
BenchmarkJsonParserObjectEachStructSmall-4    	 5000000	      1127 ns/op	     240 B/op	       8 allocs/op
```
