### PR TITLE
fixed the bug that searchKeys would return value != -1 when the keys …

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -166,10 +166,10 @@ func searchKeys(data []byte, keys ...string) int {
 		case '{':
 			level++
 		case '}':
-			if keyLevel > 0 {
+			level--
+			if level == keyLevel {
 				keyLevel--
 			}
-			level--
 		case '[':
 			// Do not search for keys inside arrays
 			if arraySkip := blockEnd(data[i:], '[', ']'); arraySkip == -1 {

--- a/parser.go
+++ b/parser.go
@@ -166,6 +166,9 @@ func searchKeys(data []byte, keys ...string) int {
 		case '{':
 			level++
 		case '}':
+			if keyLevel > 0 {
+				keyLevel--
+			}
 			level--
 		case '[':
 			// Do not search for keys inside arrays

--- a/parser_test.go
+++ b/parser_test.go
@@ -40,6 +40,7 @@ type GetTest struct {
 
 var getTests = []GetTest{
 	// Found key tests
+
 	GetTest{
 		desc:    "handling multiple nested keys with same name",
 		json:    `{"a":[{"b":1},{"b":2},3],"c":{"c":[1,2]}} }`,
@@ -253,6 +254,12 @@ var getTests = []GetTest{
 		desc:    `handle escaped quote in key name in JSON`,
 		json:    `{"key\"key": 1}`,
 		path:    []string{"key"},
+		isFound: false,
+	},
+	GetTest{
+		desc:    "handling multiple keys with different name",
+		json:    `{"a":{"a":1},"b":{"a":3,"c":[1,2]}}`,
+		path:    []string{"a", "c"},
 		isFound: false,
 	},
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -261,6 +261,13 @@ var getTests = []GetTest{
 		path:    []string{"a", "c"},
 		isFound: false,
 	},
+	GetTest{
+		desc:    "handling nested json",
+		json:    `{"a":{"b":{"c":1},"d":4}}`,
+		path:    []string{"a", "d"},
+		isFound: true,
+		data:    `4`,
+	},
 
 	// Error/invalid tests
 	GetTest{

--- a/parser_test.go
+++ b/parser_test.go
@@ -40,7 +40,6 @@ type GetTest struct {
 
 var getTests = []GetTest{
 	// Found key tests
-
 	GetTest{
 		desc:    "handling multiple nested keys with same name",
 		json:    `{"a":[{"b":1},{"b":2},3],"c":{"c":[1,2]}} }`,


### PR DESCRIPTION
**Description**: What this PR does
fixed the bug that searchKeys would return value != -1 when the keys located in different json entry 

For example, trying to search keys ["a", "c"] on following JSON should be failed: 
```json
{
    "a": {
        "a": 1
    },
    "b": {
        "a": 3,
        "c": [1, 2]
    }
}
```


**Benchmark before change**:
BenchmarkJsonParserLarge-4                    	  100000	     72548 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserMedium-4                   	  500000	     11408 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-4      	 1000000	      6554 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyStructMedium-4      	 1000000	      7190 ns/op	     544 B/op	      11 allocs/op
BenchmarkJsonParserObjectEachStructMedium-4   	  500000	     11854 ns/op	     608 B/op	      12 allocs/op
BenchmarkJsonParserSmall-4                    	10000000	       993 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-4       	10000000	       634 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyStructSmall-4       	10000000	      1047 ns/op	     176 B/op	       7 allocs/op
BenchmarkJsonParserObjectEachStructSmall-4    	10000000	       975 ns/op	     240 B/op	       8 allocs/op
PASS
ok  	jsonparser/benchmark	74.007s

**Benchmark after change**:
BenchmarkJsonParserLarge-4                    	  100000	     72744 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserMedium-4                   	  500000	     13456 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-4      	 1000000	      6479 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyStructMedium-4      	 1000000	      7017 ns/op	     544 B/op	      11 allocs/op
BenchmarkJsonParserObjectEachStructMedium-4   	  500000	     11701 ns/op	     608 B/op	      12 allocs/op
BenchmarkJsonParserSmall-4                    	10000000	      1002 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-4       	10000000	       626 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyStructSmall-4       	10000000	      1064 ns/op	     176 B/op	       7 allocs/op
BenchmarkJsonParserObjectEachStructSmall-4    	10000000	      1037 ns/op	     240 B/op	       8 allocs/op
PASS
ok  	jsonparser/benchmark	75.685s

For running benchmarks use:
```
go test -test.benchmem -bench JsonParser ./benchmark/ -benchtime 5s -v
# OR
make bench (runs inside docker)
```
…located in different json entry

For example, this json object, when looking for keys [‘a’, ‘c’],
searchKeys should return a negative value, use to return possible which
could cause wrong data for Get API
{
    "a": {
        "a": 1
    },
    "b": {
        "a": 3,
        "c": [1, 2]
    }
}