### PR TITLE
Add support for array idx keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,34 @@ jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, off
 	fmt.Println(jsonparser.Get(value, "url"))
 }, "person", "avatars")
 
+// Or use can access fields by index!
+jsonparser.GetInt("person", "avatars", "[0]", "url")
+
 // You can use `ObjectEach` helper to iterate objects { "key1":object1, "key2":object2, .... "keyN":objectN }
 jsonparser.ObjectEach(data, func(key []byte, value []byte, dataType jsonparser.ValueType, offset int) error {
         fmt.Printf("Key: '%s'\n Value: '%s'\n Type: %s\n", string(key), string(value), dataType)
 	return nil
 }, "person", "name")
+
+// The most efficient way to extract multiple keys is `EachKey`
+
+paths := [][]string{
+  []string{"person", "name", "fullName"},
+  []string{"person", "avatars", "[0]", "url"},
+  []string{"company", "url"},
+}
+jsonparser.EachKey(data, func(idx int, value []byte, vt jsonparser.ValueType, err error){
+  switch idx {
+  case 0: // []string{"person", "name", "fullName"}
+    ...
+  case 1: // []string{"person", "avatars", "[0]", "url"}
+    ...
+  case 2: // []string{"company", "url"},
+    ...
+  }
+}, paths...)
+
+// For more information see docs below
 ```
 
 ## Need to speedup your app?
@@ -92,6 +115,8 @@ Returns:
 
 Accepts multiple keys to specify path to JSON value (in case of quering nested structures).
 If no keys are provided it will try to extract the closest JSON value (simple ones or object/array), useful for reading streams or arrays, see `ArrayEach` implementation.
+
+Note that keys can be an array indexes: `jsonparser.GetInt("person", "avatars", "[0]", "url")`, pretty cool, yeah?
 
 ### **`GetString`**
 ```go

--- a/parser_test.go
+++ b/parser_test.go
@@ -333,6 +333,62 @@ var getTests = []GetTest{
 		isFound: true,
 		data:    "c",
 	},
+
+	// Array index paths
+	GetTest{
+		desc:    "last key in path is index",
+		json:    `{"a":[{"b":1},{"b":"2"}, 3],"c":{"c":[1,2]}}`,
+		path:    []string{"a", "[1]"},
+		isFound: true,
+		data:    `{"b":"2"}`,
+	},
+	GetTest{
+		desc:    "key in path is index",
+		json:    `{"a":[{"b":"1"},{"b":"2"},3],"c":{"c":[1,2]}}`,
+		path:    []string{"a", "[0]", "b"},
+		isFound: true,
+		data:    `1`,
+	},
+	GetTest{
+		desc: "last key in path is an index to value in array (formatted json)",
+		json: `{
+		    "a": [
+			{
+			    "b": 1
+			},
+			{"b":"2"},
+			3
+		    ],
+		    "c": {
+			"c": [
+			    1,
+			    2
+			]
+		    }
+		}`,
+		path:    []string{"a", "[1]"},
+		isFound: true,
+		data:    `{"b":"2"}`,
+	},
+	GetTest{
+		desc: "key in path is index (formatted json)",
+		json: `{
+		    "a": [
+			{"b": 1},
+			{"b": "2"},
+			3
+		    ],
+		    "c": {
+			"c": [
+			    1,
+			    2
+			]
+		    }
+		}`,
+		path:    []string{"a", "[0]", "b"},
+		isFound: true,
+		data:    `1`,
+	},
 }
 
 var getIntTests = []GetTest{
@@ -520,7 +576,7 @@ func runGetTests(t *testing.T, testKind string, tests []GetTest, runner func(Get
 			continue
 		}
 
-		// fmt.Println("Running:", test.desc)
+		fmt.Println("Running:", test.desc)
 
 		value, dataType, err := runner(test)
 
@@ -822,6 +878,9 @@ func TestEachKey(t *testing.T) {
 		[]string{"nested", "b"},
 		[]string{"nested2", "a"},
 		[]string{"nested", "nested3", "b"},
+		[]string{"arr", "[1]", "b"},
+		[]string{"arrInt", "[3]"},
+		[]string{"arrInt", "[5]"}, // Should not find last key
 	}
 
 	keysFound := 0
@@ -832,7 +891,7 @@ func TestEachKey(t *testing.T) {
 		switch idx {
 		case 0:
 			if string(value) != "Name" {
-				t.Errorf("Should find 1 key")
+				t.Error("Should find 1 key", string(value))
 			}
 		case 1:
 			if string(value) != "Order" {
@@ -840,27 +899,35 @@ func TestEachKey(t *testing.T) {
 			}
 		case 2:
 			if string(value) != "test" {
-				t.Errorf("Should find 2 key")
+				t.Errorf("Should find 3 key")
 			}
 		case 3:
 			if string(value) != "2" {
-				t.Errorf("Should find 3 key")
+				t.Errorf("Should find 4 key")
 			}
 		case 4:
 			if string(value) != "test2" {
-				t.Error("Should find 4 key", string(value))
+				t.Error("Should find 5 key", string(value))
 			}
 		case 5:
 			if string(value) != "4" {
-				t.Errorf("Should find 5 key")
+				t.Errorf("Should find 6 key")
+			}
+		case 6:
+			if string(value) != "2" {
+				t.Errorf("Should find 7 key")
+			}
+		case 7:
+			if string(value) != "4" {
+				t.Error("Should find 8 key", string(value))
 			}
 		default:
-			t.Errorf("Should found only 6 keys")
+			t.Errorf("Should found only 8 keys")
 		}
 	}, paths...)
 
-	if keysFound != 6 {
-		t.Errorf("Should find 6 keys: %d", keysFound)
+	if keysFound != 8 {
+		t.Errorf("Should find 8 keys: %d", keysFound)
 	}
 }
 


### PR DESCRIPTION
Now you can use array indexes as keys: `jsonparser.GetInt("person", "avatars", "[0]", "url”)`

And it even works when you want to extract multiple keys using `EachKey`.
