### PR TITLE
bench: add a8m/djson as a compared library #75

### DIFF
--- a/benchmark/benchmark_large_payload_test.go
+++ b/benchmark/benchmark_large_payload_test.go
@@ -11,6 +11,7 @@ import (
 	// "github.com/Jeffail/gabs"
 	// "github.com/bitly/go-simplejson"
 	"encoding/json"
+	"github.com/a8m/djson"
 	jlexer "github.com/mailru/easyjson/jlexer"
 	"github.com/pquerna/ffjson/ffjson"
 	// "github.com/antonholmquist/jason"
@@ -106,6 +107,25 @@ func BenchmarkEasyJsonLarge(b *testing.B) {
 
 		for _, t := range data.Topics.Topics {
 			nothing(t.Id, t.Slug)
+		}
+	}
+}
+
+/*
+   github.com/a8m/djson
+*/
+func BenchmarkDjsonLarge(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		m, _ := djson.DecodeObject(largeFixture)
+		users := m["users"].([]interface{})
+		for _, u := range users {
+			nothing(u.(map[string]interface{})["username"].(string))
+		}
+
+		topics := m["topics"].(map[string]interface{})["topics"].([]interface{})
+		for _, t := range topics {
+			tI := t.(map[string]interface{})
+			nothing(tI["id"].(float64), tI["slug"].(string))
 		}
 	}
 }

--- a/benchmark/benchmark_medium_payload_test.go
+++ b/benchmark/benchmark_medium_payload_test.go
@@ -7,6 +7,7 @@ package benchmark
 import (
 	"encoding/json"
 	"github.com/Jeffail/gabs"
+	"github.com/a8m/djson"
 	"github.com/antonholmquist/jason"
 	"github.com/bitly/go-simplejson"
 	"github.com/buger/jsonparser"
@@ -279,6 +280,26 @@ func BenchmarkUjsonMedium(b *testing.B) {
 		}
 
 		nothing()
+	}
+}
+
+/*
+   github.com/a8m/djson
+*/
+func BenchmarkDjsonMedium(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		m, _ := djson.DecodeObject(mediumFixture)
+		person := m["person"].(map[string]interface{})
+		name := person["name"].(map[string]interface{})
+		github := person["github"].(map[string]interface{})
+		company := m["company"]
+		gravatar := person["gravatar"].(map[string]interface{})
+		avatars := gravatar["avatars"].([]interface{})
+
+		nothing(name["fullName"].(string), github["followers"].(float64), company)
+		for _, a := range avatars {
+			nothing(a.(map[string]interface{})["url"])
+		}
 	}
 }
 

--- a/benchmark/benchmark_small_payload_test.go
+++ b/benchmark/benchmark_small_payload_test.go
@@ -7,6 +7,7 @@ package benchmark
 import (
 	"encoding/json"
 	"github.com/Jeffail/gabs"
+	"github.com/a8m/djson"
 	"github.com/antonholmquist/jason"
 	"github.com/bitly/go-simplejson"
 	"github.com/buger/jsonparser"
@@ -218,7 +219,6 @@ func BenchmarkJasonSmall(b *testing.B) {
 /*
    github.com/mreiferson/go-ujson
 */
-
 func BenchmarkUjsonSmall(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		json, _ := ujson.NewFromBytes(smallFixture)
@@ -229,6 +229,16 @@ func BenchmarkUjsonSmall(b *testing.B) {
 		json.Get("st").Float64()
 
 		nothing()
+	}
+}
+
+/*
+   github.com/a8m/djson
+*/
+func BenchmarkDjsonSmall(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		m, _ := djson.DecodeObject(smallFixture)
+		nothing(m["uuid"].(string), m["tz"].(float64), m["ua"].(string), m["st"].(float64))
 	}
 }
 


### PR DESCRIPTION
Benchmark results running on my machine. 

__Small payload:__
```
Jason                      	  500000	     19378 ns/op	    7237 B/op	     101 allocs/op
GoSimplejson               	 1000000	     10394 ns/op	    2241 B/op	      36 allocs/op
EncodingJsonStruct         	 1000000	      6645 ns/op	     896 B/op	      18 allocs/op
EncodingJsonInterface      	 1000000	      6835 ns/op	    1521 B/op	      38 allocs/op
Gabs                       	 1000000	      8909 ns/op	    1649 B/op	      46 allocs/op
Ugirji                     	 1000000	      6061 ns/op	    2192 B/op	      31 allocs/op
Ujson                      	 1000000	      5005 ns/op	    1409 B/op	      37 allocs/op
Djson                      	 2000000	      3862 ns/op	    1249 B/op	      30 allocs/op
FFJson                     	 2000000	      2909 ns/op	     640 B/op	      15 allocs/op
EasyJson                   	 5000000	      1516 ns/op	     192 B/op	       9 allocs/op
JsonParserEachKeyStruct    	 5000000	      1408 ns/op	     256 B/op	       9 allocs/op
JsonParserObjectEachStruct 	10000000	      1307 ns/op	     240 B/op	       8 allocs/op
JsonParser                 	10000000	      1247 ns/op	       0 B/op	       0 allocs/op
JsonParserEachKeyManual    	10000000	       879 ns/op	      80 B/op	       2 allocs/op
```

__Medium payload:__
```
Ugirji                     	  100000	     82743 ns/op	    6744 B/op	     152 allocs/op
GoSimpleJson               	  100000	     72283 ns/op	   17187 B/op	     220 allocs/op
Jason                      	  100000	     65327 ns/op	   19011 B/op	     247 allocs/op
Gabs                       	  200000	     61142 ns/op	   11203 B/op	     235 allocs/op
EncodingJsonInterface      	  200000	     54524 ns/op	   10628 B/op	     215 allocs/op
EncodingJsonStruct         	  200000	     44017 ns/op	    1352 B/op	      29 allocs/op
Ujson                      	  200000	     40595 ns/op	   11546 B/op	     270 allocs/op
Djson                      	  200000	     28525 ns/op	   10196 B/op	     198 allocs/op
FFJson                     	  500000	     15223 ns/op	     872 B/op	      20 allocs/op
JsonParser                 	  500000	     14133 ns/op	       0 B/op	       0 allocs/op
JsonParserObjectEachStruct 	  500000	     12690 ns/op	     608 B/op	      12 allocs/op
EasyJson                   	 1000000	      9644 ns/op	     336 B/op	      12 allocs/op
JsonParserEachKeyStruct    	 1000000	      9413 ns/op	     656 B/op	      13 allocs/op
JsonParserEachKeyManual    	 1000000	      8214 ns/op	     112 B/op	       2 allocs/op
```

__Large payload:__
```
EncodingJsonInterface 	   10000	    832589 ns/op	  215443 B/op	    3395 allocs/op
EncodingJsonStruct    	   10000	    563462 ns/op	    8289 B/op	     307 allocs/op
Djson                 	   10000	    510082 ns/op	  213682 B/op	    2845 allocs/op
FFJson                	   30000	    221558 ns/op	    7808 B/op	     298 allocs/op
EasyJson              	   50000	    141397 ns/op	    6992 B/op	     288 allocs/op
JsonParser            	  100000	     74333 ns/op	       0 B/op	       0 allocs/op
```

I guess you want to run the benchmarks on your machine, and then update the README.

Thanks 😃 