### PR TITLE
added fix for issue #83

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -574,6 +574,10 @@ func ArrayEach(data []byte, cb func(value []byte, dataType ValueType, offset int
 	for true {
 		v, t, o, e := Get(data[offset:])
 
+		if e != nil {
+			return offset, e
+		}
+
 		if o == 0 {
 			break
 		}


### PR DESCRIPTION
**Description**: What this PR does
fixes issue #83 
With this implementation it no longer makes sense to pass err to the callback function, since in the event of a parse error from get the cb function does not get called anymore.
Then again since the cb function is unable to propagate the error anyway (issue #53 ) the whole way errors in the cb function are handled seems odd to me, but this is debatable ofcourse. 