### PR TITLE
Added JsonValue OO abstractions, making the api much simpler and fixes some issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ RUN go get github.com/mreiferson/go-ujson
 RUN go get -tags=unsafe -u github.com/ugorji/go/codec
 RUN go get github.com/mailru/easyjson
 
-WORKDIR /go/src/github.com/buger/jsonparser
-ADD . /go/src/github.com/buger/jsonparser
+WORKDIR /go/src/github.com/stverhae/jsonparser
+ADD . /go/src/github.com/stverhae/jsonparser

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SOURCE = parser.go
 CONTAINER = jsonparser
-SOURCE_PATH = /go/src/github.com/buger/jsonparser
-BENCHMARK = JsonParser
+SOURCE_PATH = /go/src/github.com/stverhae/jsonparser
+BENCHMARK = JsonValue
 BENCHTIME = 5s
 TEST = .
 DRUN = docker run -v `pwd`:$(SOURCE_PATH) -i -t $(CONTAINER)

--- a/benchmark/benchmark_large_payload_test.go
+++ b/benchmark/benchmark_large_payload_test.go
@@ -6,7 +6,7 @@
 package benchmark
 
 import (
-	"github.com/buger/jsonparser"
+	"github.com/stverhae/jsonparser"
 	"testing"
 	// "github.com/Jeffail/gabs"
 	// "github.com/bitly/go-simplejson"
@@ -32,6 +32,21 @@ func BenchmarkJsonParserLarge(b *testing.B) {
 			jsonparser.Get(value, "slug")
 			nothing()
 		}, "topics", "topics")
+	}
+}
+
+func BenchmarkJsonValueLarge(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		json := jsonparser.ParseJson(largeFixture)
+		json.Get("users").ArrayEach(func(value *jsonparser.JsonValue) {
+			value.Get("username")
+			nothing()
+		})
+		json.Get("topics", "topics").ArrayEach(func(value *jsonparser.JsonValue) {
+			value.GetInt("id")
+			value.Get("slug")
+			nothing()
+		})
 	}
 }
 

--- a/benchmark/benchmark_medium_payload_test.go
+++ b/benchmark/benchmark_medium_payload_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/Jeffail/gabs"
 	"github.com/antonholmquist/jason"
 	"github.com/bitly/go-simplejson"
-	"github.com/buger/jsonparser"
+	"github.com/stverhae/jsonparser"
 	jlexer "github.com/mailru/easyjson/jlexer"
 	"github.com/mreiferson/go-ujson"
 	"github.com/pquerna/ffjson/ffjson"
@@ -33,6 +33,20 @@ func BenchmarkJsonParserMedium(b *testing.B) {
 			jsonparser.Get(value, "url")
 			nothing()
 		}, "person", "gravatar", "avatars")
+	}
+}
+
+func BenchmarkJsonValueMedium(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		json := jsonparser.ParseJson(mediumFixture)
+		json.Get("person", "name", "fullName")
+		json.GetInt("person", "github", "followers")
+		json.Get("company")
+
+		json.Get("person", "gravatar", "avatars").ArrayEach(func(value *jsonparser.JsonValue) {
+			value.Get("url")
+			nothing()
+		})
 	}
 }
 
@@ -61,6 +75,34 @@ func BenchmarkJsonParserEachKeyManualMedium(b *testing.B) {
 		}, paths...)
 	}
 }
+
+func BenchmarkJsonValueEachKeyManualMedium(b *testing.B) {
+	paths := [][]string{
+		[]string{"person", "name", "fullName"},
+		[]string{"person", "github", "followers"},
+		[]string{"company"},
+		[]string{"person", "gravatar", "avatars"},
+	}
+
+	for i := 0; i < b.N; i++ {
+		json := jsonparser.ParseJson(mediumFixture)
+		json.EachKey(func(idx int, value *jsonparser.JsonValue) {
+			switch idx {
+			case 0:
+			// jsonparser.ParseString(value)
+			case 1:
+				value.GetInt()
+			case 2:
+			// jsonparser.ParseString(value)
+			case 3:
+				value.ArrayEach(func(value2 *jsonparser.JsonValue) {
+					value2.Get("url")
+				})
+			}
+		}, paths...)
+	}
+}
+
 
 func BenchmarkJsonParserEachKeyStructMedium(b *testing.B) {
 	paths := [][]string{
@@ -92,6 +134,45 @@ func BenchmarkJsonParserEachKeyStructMedium(b *testing.B) {
 				var avatars []*CBAvatar
 				jsonparser.ArrayEach(value, func(avalue []byte, dataType jsonparser.ValueType, offset int, err error) {
 					url, _ := jsonparser.ParseString(avalue)
+					avatars = append(avatars, &CBAvatar{Url: url})
+				})
+				data.Person.Gravatar.Avatars = avatars
+			}
+		}, paths...)
+	}
+}
+
+func BenchmarkJsonValueEachKeyStructMedium(b *testing.B) {
+	paths := [][]string{
+		[]string{"person", "name", "fullName"},
+		[]string{"person", "github", "followers"},
+		[]string{"company"},
+		[]string{"person", "gravatar", "avatars"},
+	}
+
+	for i := 0; i < b.N; i++ {
+		data := MediumPayload{
+			Person: &CBPerson{
+				Name:     &CBName{},
+				Github:   &CBGithub{},
+				Gravatar: &CBGravatar{},
+			},
+		}
+
+		json := jsonparser.ParseJson(mediumFixture)
+		json.EachKey(func(idx int, value *jsonparser.JsonValue) {
+			switch idx {
+			case 0:
+				data.Person.Name.FullName, _ = value.GetString()
+			case 1:
+				v, _ := value.GetInt()
+				data.Person.Github.Followers = int(v)
+			case 2:
+				value.ToMap()
+			case 3:
+				var avatars []*CBAvatar
+				value.ArrayEach(func(value2 *jsonparser.JsonValue) {
+					url, _ := value2.GetString()
 					avatars = append(avatars, &CBAvatar{Url: url})
 				})
 				data.Person.Gravatar.Avatars = avatars
@@ -143,6 +224,38 @@ func BenchmarkJsonParserObjectEachStructMedium(b *testing.B) {
 
 		cv, _, _, _ := jsonparser.Get(mediumFixture, "company")
 		json.Unmarshal(cv, &data.Company)
+	}
+}
+
+func BenchmarkJsonValueObjectEachStructMedium(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		data := MediumPayload{
+			Person: &CBPerson{
+				Name:     &CBName{},
+				Github:   &CBGithub{},
+				Gravatar: &CBGravatar{},
+			},
+		}
+
+		json := jsonparser.ParseJson(mediumFixture)
+		json.Get("person").ObjectEach(func(key string, value *jsonparser.JsonValue) {
+			switch(key) {
+			case "name":
+				data.Person.Name.FullName, _ = value.GetString("fullName")
+			case "github":
+				x, _ := value.GetInt("followers")
+				data.Person.Github.Followers = int(x)
+			case "gravatar":
+				var avatars []*CBAvatar
+				value.Get("avatars").ArrayEach(func(avatar *jsonparser.JsonValue) {
+					url, _ := avatar.GetString()
+					avatars = append(avatars, &CBAvatar{Url: url})
+				})
+				data.Person.Gravatar.Avatars = avatars
+			}
+		})
+
+		json.Get("company").ToMap()
 	}
 }
 

--- a/benchmark/benchmark_small_payload_test.go
+++ b/benchmark/benchmark_small_payload_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/Jeffail/gabs"
 	"github.com/antonholmquist/jason"
 	"github.com/bitly/go-simplejson"
-	"github.com/buger/jsonparser"
+	"github.com/stverhae/jsonparser"
 	jlexer "github.com/mailru/easyjson/jlexer"
 	"github.com/mreiferson/go-ujson"
 	"github.com/pquerna/ffjson/ffjson"
@@ -37,6 +37,19 @@ func BenchmarkJsonParserSmall(b *testing.B) {
 	}
 }
 
+func BenchmarkJsonValueSmall(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		json := jsonparser.ParseJson(smallFixture)
+		json.Get("uuid")
+		json.GetInt("tz")
+		json.Get("ua")
+		json.GetInt("st")
+
+		nothing()
+	}
+}
+
+
 func BenchmarkJsonParserEachKeyManualSmall(b *testing.B) {
 	paths := [][]string{
 		[]string{"uuid"},
@@ -56,6 +69,31 @@ func BenchmarkJsonParserEachKeyManualSmall(b *testing.B) {
 				// jsonparser.ParseString(value)
 			case 3:
 				jsonparser.ParseInt(value)
+			}
+		}, paths...)
+	}
+}
+
+func BenchmarkJsonValueEachKeyManualSmall(b *testing.B) {
+	paths := [][]string{
+		[]string{"uuid"},
+		[]string{"tz"},
+		[]string{"ua"},
+		[]string{"st"},
+	}
+
+	for i := 0; i < b.N; i++ {
+		json := jsonparser.ParseJson(smallFixture)
+		json.EachKey(func(idx int, value *jsonparser.JsonValue) {
+			switch idx {
+			case 0:
+			// jsonparser.ParseString(value)
+			case 1:
+				value.GetInt()
+			case 2:
+			// jsonparser.ParseString(value)
+			case 3:
+				value.GetInt()
 			}
 		}, paths...)
 	}
@@ -83,6 +121,37 @@ func BenchmarkJsonParserEachKeyStructSmall(b *testing.B) {
 				data.Ua, _ = jsonparser.ParseString(value)
 			case 3:
 				v, _ := jsonparser.ParseInt(value)
+				data.St = int(v)
+			}
+		}, paths...)
+
+		nothing(data.Uuid, data.Tz, data.Ua, data.St)
+	}
+}
+
+func BenchmarkJsonValueEachKeyStructSmall(b *testing.B) {
+	paths := [][]string{
+		[]string{"uuid"},
+		[]string{"tz"},
+		[]string{"ua"},
+		[]string{"st"},
+	}
+
+	for i := 0; i < b.N; i++ {
+		var data SmallPayload
+
+		json := jsonparser.ParseJson(smallFixture)
+		json.EachKey(func(idx int, value *jsonparser.JsonValue) {
+			switch idx {
+			case 0:
+				data.Uuid, _ = value.GetString()
+			case 1:
+				v, _ := value.GetInt()
+				data.Tz = int(v)
+			case 2:
+				data.Ua, _ = value.GetString()
+			case 3:
+				v, _ := value.GetInt()
 				data.St = int(v)
 			}
 		}, paths...)
@@ -123,6 +192,38 @@ func BenchmarkJsonParserObjectEachStructSmall(b *testing.B) {
 			} else {
 				return nil
 			}
+		})
+
+		nothing(data.Uuid, data.Tz, data.Ua, data.St)
+	}
+}
+
+func BenchmarkJsonValueObjectEachStructSmall(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var data SmallPayload
+
+		missing := 4
+
+		json := jsonparser.ParseJson(smallFixture)
+		json.ObjectEach(func(key string, value *jsonparser.JsonValue) {
+			switch {
+			case key == "uuid":
+				data.Uuid, _ = value.GetString()
+				missing--
+			case key == "tz":
+				v, _ := value.GetInt()
+				data.Tz = int(v)
+				missing--
+			case key == "ua":
+				data.Ua, _ = value.GetString()
+				missing--
+			case key == "st":
+				v, _ := value.GetInt()
+				data.St = int(v)
+				missing--
+			}
+
+			//Keeps going until the full object is parsed, unlike the base version
 		})
 
 		nothing(data.Uuid, data.Tz, data.Ua, data.St)

--- a/bytes.go
+++ b/bytes.go
@@ -1,5 +1,7 @@
 package jsonparser
 
+import "math"
+
 // About 3x faster then strconv.ParseInt because does not check for range error and support only base 10, which is enough for JSON
 func parseInt(bytes []byte) (v int64, ok bool) {
 	if len(bytes) == 0 {
@@ -18,6 +20,11 @@ func parseInt(bytes []byte) (v int64, ok bool) {
 		} else {
 			return 0, false
 		}
+	}
+
+	//check for overflows!
+	if len(bytes) >= 20 && v != 0 && math.Pow10(len(bytes)-1) > float64(v) {
+		return 0, false
 	}
 
 	if neg {

--- a/parser.go
+++ b/parser.go
@@ -887,7 +887,25 @@ func (jv *JsonValue) Index(indices ...int) (*JsonValue, error) {
 	return &JsonValue{data: v, Type: t}, nil
 }
 
-func (jv *JsonValue) ArrayEach(cb func(jsonValue *JsonValue) error) error {
+func (jv *JsonValue) ArrayEach(cb func(jsonValue *JsonValue)) error {
+	_, err := ArrayEach(jv.data, func(value []byte, dataType ValueType, offset int, err error) {
+		cb(&JsonValue{data: value, Type: dataType})
+	})
+
+	return err
+}
+
+func (jv *JsonValue) ArrayEachWithIndex(cb func(idx int, jsonValue *JsonValue)) error {
+	idx := 0
+	_, err := ArrayEach(jv.data, func(value []byte, dataType ValueType, offset int, err error) {
+		cb(idx, &JsonValue{data: value, Type: dataType})
+		idx++
+	})
+
+	return err
+}
+
+func (jv *JsonValue) ArrayEachWithError(cb func(jsonValue *JsonValue) error) error {
 	var cbErr error
 	_, err := ArrayEach(jv.data, func(value []byte, dataType ValueType, offset int, err error) {
 		if cbErr == nil {
@@ -907,6 +925,23 @@ func (jv *JsonValue) ArrayEach(cb func(jsonValue *JsonValue) error) error {
 	}
 
 	return err
+}
+
+func (jv *JsonValue) ToArray() ([]*JsonValue, error) {
+	var res []*JsonValue
+	_, err := ArrayEach(jv.data, func(value []byte, dataType ValueType, offset int, err error) {
+		res = append(res, &JsonValue{data: value, Type: dataType})
+	})
+
+	return res, err
+}
+
+func (jv *JsonValue) String() string {
+	return string(jv.data)
+}
+
+func (jv *JsonValue) RawBytes() []byte {
+	return jv.data
 }
 
 func isFloat(b []byte) bool {

--- a/parser.go
+++ b/parser.go
@@ -993,11 +993,27 @@ func (jv *JsonValue) IsNumber() bool {
 	return jv.Type == Number
 }
 
-func (jv *JsonValue) ParseInt() (int64, error) {
+func (jv *JsonValue) GetInt(keys ...string) (int64, error) {
+	if len(keys) == 0 {
+		return jv.parseInt()
+	} else {
+		return jv.Get(keys...).parseInt()
+	}
+}
+
+func (jv *JsonValue) parseInt() (int64, error) {
 	return ParseInt(jv.data)
 }
 
-func (jv *JsonValue) ParseFloat() (float64, error) {
+func (jv *JsonValue) GetFloat(keys ...string) (float64, error) {
+	if len(keys) == 0 {
+		return jv.parseFloat()
+	} else {
+		return jv.Get(keys...).parseFloat()
+	}
+}
+
+func (jv *JsonValue) parseFloat() (float64, error) {
 	return ParseFloat(jv.data)
 }
 
@@ -1005,7 +1021,15 @@ func (jv *JsonValue) IsBoolean() bool {
 	return jv.Type == Boolean
 }
 
-func (jv *JsonValue) ParseBoolean() (bool, error) {
+func (jv *JsonValue) GetBool(keys ...string) (bool, error) {
+	if len(keys) == 0 {
+		return jv.parseBool()
+	} else {
+		return jv.Get(keys...).parseBool()
+	}
+}
+
+func (jv *JsonValue) parseBool() (bool, error) {
 	return ParseBoolean(jv.data)
 }
 
@@ -1013,6 +1037,106 @@ func (jv *JsonValue) IsString() bool {
 	return jv.Type == String
 }
 
-func (jv *JsonValue) ParseString() (string, error) {
+func (jv *JsonValue) GetString(keys ...string) (string, error) {
+	if len(keys) == 0 {
+		return jv.parseString()
+	} else {
+		return jv.Get(keys...).parseString()
+	}
+}
+
+func (jv *JsonValue) parseString() (string, error) {
 	return ParseString(jv.data)
+}
+
+func (jv *JsonValue) GetStringArray(keys ...string) ([]string, error) {
+	if len(keys) == 0 {
+		return jv.parseStringArray()
+	} else {
+		return jv.Get(keys...).parseStringArray()
+	}
+}
+
+func (jv *JsonValue) parseStringArray() (res []string, err error) {
+	if jv.Type != Array {
+		return nil, fmt.Errorf("parseStringArray can only be executed on an Array not on a '%v'", jv.Type.String())
+	}
+	err = jv.ArrayEachWithError(func(value *JsonValue) error {
+		if val, err := value.GetString(); err != nil {
+			return err
+		} else {
+			res = append(res, val)
+		}
+		return nil
+	})
+	return
+}
+
+func (jv *JsonValue) GetIntArray(keys ...string) ([]int64, error) {
+	if len(keys) == 0 {
+		return jv.parseIntArray()
+	} else {
+		return jv.Get(keys...).parseIntArray()
+	}
+}
+
+func (jv *JsonValue) parseIntArray() (res []int64, err error) {
+	if jv.Type != Array {
+		return nil, fmt.Errorf("parseIntArray can only be executed on an Array not on a '%v'", jv.Type.String())
+	}
+	err = jv.ArrayEachWithError(func(value *JsonValue) error {
+		if val, err := value.GetInt(); err != nil {
+			return err
+		} else {
+			res = append(res, val)
+		}
+		return nil
+	})
+	return
+}
+
+func (jv *JsonValue) GetFloatArray(keys ...string) ([]float64, error) {
+	if len(keys) == 0 {
+		return jv.parseFloatArray()
+	} else {
+		return jv.Get(keys...).parseFloatArray()
+	}
+}
+
+func (jv *JsonValue) parseFloatArray() (res []float64, err error) {
+	if jv.Type != Array {
+		return nil, fmt.Errorf("parseFloatArray can only be executed on an Array not on a '%v'", jv.Type.String())
+	}
+	err = jv.ArrayEachWithError(func(value *JsonValue) error {
+		if val, err := value.GetFloat(); err != nil {
+			return err
+		} else {
+			res = append(res, val)
+		}
+		return nil
+	})
+	return
+}
+
+func (jv *JsonValue) GetBoolArray(keys ...string) ([]bool, error) {
+	if len(keys) == 0 {
+		return jv.parseBoolArray()
+	} else {
+		return jv.Get(keys...).parseBoolArray()
+	}
+}
+
+func (jv *JsonValue) parseBoolArray() (res []bool, err error) {
+	if jv.Type != Array {
+		return nil, fmt.Errorf("parseBoolArray can only be executed on an Array not on a '%v'", jv.Type.String())
+	}
+	err = jv.ArrayEachWithError(func(value *JsonValue) error {
+		if val, err := value.GetBool(); err != nil {
+			return err
+		} else {
+			res = append(res, val)
+		}
+		return nil
+	})
+	return
 }

--- a/parser.go
+++ b/parser.go
@@ -869,6 +869,14 @@ func (jv *JsonValue) Get(keys ...string) (*JsonValue, error) {
 	return &JsonValue{data: v, Type: t}, nil
 }
 
+func (jv *JsonValue) IsObject() bool {
+	return jv.Type == Object
+}
+
+func (jv *JsonValue) IsArray() bool {
+	return jv.Type == Array
+}
+
 func (jv *JsonValue) Index(indices ...int) (*JsonValue, error) {
 	if jv.Type != Array {
 		return nil, fmt.Errorf("Index only supported for Array not %v", jv.Type.String())
@@ -887,7 +895,7 @@ func (jv *JsonValue) Index(indices ...int) (*JsonValue, error) {
 	return &JsonValue{data: v, Type: t}, nil
 }
 
-func (jv *JsonValue) ArrayEach(cb func(jsonValue *JsonValue)) error {
+func (jv *JsonValue) ArrayEach(cb func(value *JsonValue)) error {
 	_, err := ArrayEach(jv.data, func(value []byte, dataType ValueType, offset int, err error) {
 		cb(&JsonValue{data: value, Type: dataType})
 	})
@@ -895,7 +903,7 @@ func (jv *JsonValue) ArrayEach(cb func(jsonValue *JsonValue)) error {
 	return err
 }
 
-func (jv *JsonValue) ArrayEachWithIndex(cb func(idx int, jsonValue *JsonValue)) error {
+func (jv *JsonValue) ArrayEachWithIndex(cb func(idx int, value *JsonValue)) error {
 	idx := 0
 	_, err := ArrayEach(jv.data, func(value []byte, dataType ValueType, offset int, err error) {
 		cb(idx, &JsonValue{data: value, Type: dataType})
@@ -905,7 +913,7 @@ func (jv *JsonValue) ArrayEachWithIndex(cb func(idx int, jsonValue *JsonValue)) 
 	return err
 }
 
-func (jv *JsonValue) ArrayEachWithError(cb func(jsonValue *JsonValue) error) error {
+func (jv *JsonValue) ArrayEachWithError(cb func(value *JsonValue) error) error {
 	var cbErr error
 	_, err := ArrayEach(jv.data, func(value []byte, dataType ValueType, offset int, err error) {
 		if cbErr == nil {
@@ -957,8 +965,8 @@ func (jv *JsonValue) IsFloat() bool {
 	return jv.Type == Number && isFloat(jv.data)
 }
 
-func (jv *JsonValue) ParseBoolean() (bool, error) {
-	return ParseBoolean(jv.data)
+func (jv *JsonValue) IsNumber() bool {
+	return jv.Type == Number
 }
 
 func (jv *JsonValue) ParseInt() (int64, error) {
@@ -967,6 +975,18 @@ func (jv *JsonValue) ParseInt() (int64, error) {
 
 func (jv *JsonValue) ParseFloat() (float64, error) {
 	return ParseFloat(jv.data)
+}
+
+func (jv *JsonValue) IsBoolean() bool {
+	return jv.Type == Boolean
+}
+
+func (jv *JsonValue) ParseBoolean() (bool, error) {
+	return ParseBoolean(jv.data)
+}
+
+func (jv *JsonValue) IsString() bool {
+	return jv.Type == String
 }
 
 func (jv *JsonValue) ParseString() (string, error) {

--- a/parser.go
+++ b/parser.go
@@ -569,12 +569,12 @@ func ArrayEach(data []byte, cb func(value []byte, dataType ValueType, offset int
 	for true {
 		v, t, o, e := Get(data[offset:])
 
-		if e != nil {
-			return offset, e
-		}
-
 		if o == 0 {
 			break
+		}
+
+		if e != nil {
+			return offset, e
 		}
 
 		if t != NotExist {
@@ -858,7 +858,7 @@ func (jv *JsonValue) Err() error {
 
 func (jv *JsonValue) Error() string {
 	if jv.err != nil {
-		return jv.Error()
+		return jv.err.Error()
 	} else {
 		return ""
 	}
@@ -937,7 +937,7 @@ func (jv *JsonValue) ArrayEachWithError(cb func(value *JsonValue) error) error {
 
 	var cbErr error
 	_, err := ArrayEach(jv.data, func(value []byte, dataType ValueType, offset int, err error) {
-		if cbErr == nil {
+		if cbErr != nil {
 			return //TODO: rewrite this method so it does not use arrayeach, so we can escape out of this mess ...
 		}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -44,7 +44,7 @@ var getTests = []GetTest{
 		desc:    "read string",
 		json:    `""`,
 		isFound: true,
-		data:    `""`,
+		data:    ``,
 	},
 	GetTest{
 		desc:    "read number",
@@ -84,21 +84,21 @@ var getTests = []GetTest{
 		json:    `{"a":"b"}`,
 		path:    []string{"a"},
 		isFound: true,
-		data:    `"b"`,
+		data:    `b`,
 	},
 	GetTest{
 		desc:    "read basic key with space",
 		json:    `{"a": "b"}`,
 		path:    []string{"a"},
 		isFound: true,
-		data:    `"b"`,
+		data:    `b`,
 	},
 	GetTest{
 		desc:    "read composite key",
 		json:    `{"a": { "b":{"c":"d" }}}`,
 		path:    []string{"a", "b", "c"},
 		isFound: true,
-		data:    `"d"`,
+		data:    `d`,
 	},
 	GetTest{
 		desc:    `read numberic value as string`,
@@ -119,7 +119,7 @@ var getTests = []GetTest{
 		json:    `{"a": "string\"with\"quotes"}`,
 		path:    []string{"a"},
 		isFound: true,
-		data:    `"string\"with\"quotes"`,
+		data:    `string\"with\"quotes`,
 	},
 	GetTest{
 		desc:    `read object`,
@@ -140,7 +140,7 @@ var getTests = []GetTest{
 		json:    "{\n  \"a\": \"b\"\n}",
 		path:    []string{"a"},
 		isFound: true,
-		data:    `"b"`,
+		data:    `b`,
 	},
 	GetTest{
 		desc:    `formatted JSON value 2`,
@@ -161,21 +161,21 @@ var getTests = []GetTest{
 		json:    `{"a": "\\\""}`,
 		path:    []string{"a"},
 		isFound: true,
-		data:    `"\\\""`,
+		data:    `\\\"`,
 	},
 	GetTest{
 		desc:    `unescaped backslash quote`,
 		json:    `{"a": "\\"}`,
 		path:    []string{"a"},
 		isFound: true,
-		data:    `"\\"`,
+		data:    `\\`,
 	},
 	GetTest{
 		desc:    `unicode in JSON`,
 		json:    `{"a": "15°C"}`,
 		path:    []string{"a"},
 		isFound: true,
-		data:    `"15°C"`,
+		data:    `15°C`,
 	},
 	GetTest{
 		desc:    `no padding + nested`,
@@ -212,7 +212,7 @@ var getTests = []GetTest{
 		json:    `{"key\b\f\n\r\tkey":"value\b\f\n\r\tvalue"}`,
 		path:    []string{"key\b\f\n\r\tkey"},
 		isFound: true,
-		data:    `"value\b\f\n\r\tvalue"`, // value is not unescaped since this is Get(), but the key should work correctly
+		data:    `value\b\f\n\r\tvalue`, // value is not unescaped since this is Get(), but the key should work correctly
 	},
 	GetTest{
 		desc:    `key with Unicode escape`,
@@ -313,7 +313,7 @@ var getTests = []GetTest{
 		json:    `{"a":"b"`,
 		path:    []string{"a"},
 		isFound: true,
-		data:    `"b"`,
+		data:    `b`,
 	},
 	GetTest{
 		desc:  `missing value closing quote`,
@@ -369,14 +369,14 @@ var getTests = []GetTest{
 		json:    `{"a":"b":"c"}`,
 		path:    []string{"a"},
 		isFound: true,
-		data:    `"b"`,
+		data:    "b",
 	},
 	GetTest{ // This test returns a match instead of a parse error, as checking for the malformed JSON would reduce performance (this is not ideal)
 		desc:    "malformed 'colon chain', lookup second string",
 		json:    `{"a":"b":"c"}`,
 		path:    []string{"b"},
 		isFound: true,
-		data:    `"c"`,
+		data:    "c",
 	},
 
 	// Array index paths
@@ -392,7 +392,7 @@ var getTests = []GetTest{
 		json:    `{"a":[{"b":"1"},{"b":"2"},3],"c":{"c":[1,2]}}`,
 		path:    []string{"a", "[0]", "b"},
 		isFound: true,
-		data:    `"1"`,
+		data:    `1`,
 	},
 	GetTest{
 		desc: "last key in path is an index to value in array (formatted json)",
@@ -615,13 +615,16 @@ func getTestCheckFoundAndNoError(t *testing.T, testKind string, test GetTest, jt
 	}
 }
 
-func runGetTests(t *testing.T, testKind string, tests []GetTest, runner func(GetTest) (interface{}, ValueType, error), resultChecker func(GetTest, interface{}) (bool, interface{})) {
+func runGetTests(t *testing.T, testKind string, tests []GetTest, jsonValue bool, runner func(GetTest) (interface{}, ValueType, error), resultChecker func(GetTest, interface{}) (bool, interface{})) {
 	for _, test := range tests {
 		if activeTest != "" && test.desc != activeTest {
 			continue
 		}
-
-		fmt.Println("Running:", test.desc)
+		if jsonValue {
+			fmt.Println("Running: JsonValue", test.desc)
+		} else {
+			fmt.Println("Running:", test.desc)
+		}
 
 		value, dataType, err := runner(test)
 
@@ -629,6 +632,14 @@ func runGetTests(t *testing.T, testKind string, tests []GetTest, runner func(Get
 			if test.data == nil {
 				t.Errorf("MALFORMED TEST: %v", test)
 				continue
+			}
+
+			//tests contain string results with quotes already stripped, so do this here
+			if jsonValue && dataType == String {
+				b := value.([]byte)
+				if len(b) > 1 && b[0] == '"' {
+					value = b[1 : len(b)-1]
+				}
 			}
 
 			if ok, expected := resultChecker(test, value); !ok {
@@ -645,7 +656,7 @@ func runGetTests(t *testing.T, testKind string, tests []GetTest, runner func(Get
 }
 
 func TestGet(t *testing.T) {
-	runGetTests(t, "Get()", getTests,
+	runGetTests(t, "Get()", getTests, false,
 		func(test GetTest) (value interface{}, dataType ValueType, err error) {
 			value, dataType, _, err = Get([]byte(test.json), test.path...)
 			return
@@ -658,26 +669,7 @@ func TestGet(t *testing.T) {
 }
 
 func TestJsonValueGet(t *testing.T) {
-	/*runGetTests(t, "JsonValue.Get()", getTests,
-		func(test GetTest) (value interface{}, dataType ValueType, err error) {
-			//two steps to explicitly test JsonValue.Get(). (we could just pass the keys to ParseJson)
-			if json, err := ParseJson([]byte(test.json)); err != nil {
-				return nil, Unknown, err
-			} else {
-				if json, err = json.Get(test.path...); err != nil {
-					return nil, Unknown, err
-				} else {
-					return json.data, json.Type, err
-				}
-			}
-		},
-		func(test GetTest, value interface{}) (bool, interface{}) {
-			expected := []byte(test.data.(string))
-			return bytes.Equal(expected, value.([]byte)), expected
-		},
-	)
-	*/
-	runGetTests(t, "JsonValue.Get()", getTests,
+	runGetTests(t, "JsonValue.Get()", getTests, true,
 		func(test GetTest) (value interface{}, dataType ValueType, err error) {
 			//two steps to explicitly test JsonValue.Get(). (we could just pass the keys to ParseJson)
 			if json := ParseJson([]byte(test.json), test.path...); json.Err() != nil {
@@ -685,7 +677,6 @@ func TestJsonValueGet(t *testing.T) {
 			} else {
 				return json.data, json.Type, err
 			}
-
 		},
 		func(test GetTest, value interface{}) (bool, interface{}) {
 			expected := []byte(test.data.(string))
@@ -695,7 +686,7 @@ func TestJsonValueGet(t *testing.T) {
 }
 
 func TestGetString(t *testing.T) {
-	runGetTests(t, "GetString()", getStringTests,
+	runGetTests(t, "GetString()", getStringTests, false,
 		func(test GetTest) (value interface{}, dataType ValueType, err error) {
 			value, err = GetString([]byte(test.json), test.path...)
 			return value, String, err
@@ -708,7 +699,7 @@ func TestGetString(t *testing.T) {
 }
 
 func TestGetInt(t *testing.T) {
-	runGetTests(t, "GetInt()", getIntTests,
+	runGetTests(t, "GetInt()", getIntTests, false,
 		func(test GetTest) (value interface{}, dataType ValueType, err error) {
 			value, err = GetInt([]byte(test.json), test.path...)
 			return value, Number, err
@@ -721,7 +712,7 @@ func TestGetInt(t *testing.T) {
 }
 
 func TestGetFloat(t *testing.T) {
-	runGetTests(t, "GetFloat()", getFloatTests,
+	runGetTests(t, "GetFloat()", getFloatTests, false,
 		func(test GetTest) (value interface{}, dataType ValueType, err error) {
 			value, err = GetFloat([]byte(test.json), test.path...)
 			return value, Number, err
@@ -734,7 +725,7 @@ func TestGetFloat(t *testing.T) {
 }
 
 func TestGetBoolean(t *testing.T) {
-	runGetTests(t, "GetBoolean()", getBoolTests,
+	runGetTests(t, "GetBoolean()", getBoolTests, false,
 		func(test GetTest) (value interface{}, dataType ValueType, err error) {
 			value, err = GetBoolean([]byte(test.json), test.path...)
 			return value, Boolean, err
@@ -747,7 +738,7 @@ func TestGetBoolean(t *testing.T) {
 }
 
 func TestGetSlice(t *testing.T) {
-	runGetTests(t, "Get()-for-arrays", getArrayTests,
+	runGetTests(t, "Get()-for-arrays", getArrayTests, false,
 		func(test GetTest) (value interface{}, dataType ValueType, err error) {
 			value, dataType, _, err = Get([]byte(test.json), test.path...)
 			return
@@ -851,7 +842,7 @@ var objectEachTests = []ObjectEachTest{
 		desc: "single key-value object",
 		json: `{"key": "value"}`,
 		entries: []keyValueEntry{
-			{`key`, `"value"`, String},
+			{"key", "value", String},
 		},
 	},
 	{
@@ -868,7 +859,7 @@ var objectEachTests = []ObjectEachTest{
 			{"key1", "", Null},
 			{"key2", "true", Boolean},
 			{"key3", "1.23", Number},
-			{"key4", `"string value"`, String},
+			{"key4", "string value", String},
 			{"key5", "[1,2,3]", Array},
 			{"key6", `{"a":"b"}`, Object},
 		},
@@ -877,7 +868,7 @@ var objectEachTests = []ObjectEachTest{
 		desc: "escaped key",
 		json: `{"key\"\\\/\b\f\n\r\t\u00B0": "value"}`,
 		entries: []keyValueEntry{
-			{"key\"\\/\b\f\n\r\t\u00B0", `"value"`, String},
+			{"key\"\\/\b\f\n\r\t\u00B0", "value", String},
 		},
 	},
 	// Error cases
@@ -1006,15 +997,15 @@ func TestEachKey(t *testing.T) {
 
 		switch idx {
 		case 0:
-			if string(value) != `"Name"` {
+			if string(value) != "Name" {
 				t.Error("Should find 1 key", string(value))
 			}
 		case 1:
-			if string(value) != `"Order"` {
+			if string(value) != "Order" {
 				t.Errorf("Should find 2 key")
 			}
 		case 2:
-			if string(value) != `"test"` {
+			if string(value) != "test" {
 				t.Errorf("Should find 3 key")
 			}
 		case 3:
@@ -1022,7 +1013,7 @@ func TestEachKey(t *testing.T) {
 				t.Errorf("Should find 4 key")
 			}
 		case 4:
-			if string(value) != `"test2"` {
+			if string(value) != "test2" {
 				t.Error("Should find 5 key", string(value))
 			}
 		case 5:

--- a/parser_test.go
+++ b/parser_test.go
@@ -791,38 +791,35 @@ func TestArrayEach(t *testing.T) {
 
 func TestJsonValueArrayEach(t *testing.T) {
 	mock := []byte(`{"a": { "b":[{"x": 1} ,{"x":2},{ "x":3}, {"x":4} ]}}`)
-	count := 0
 
 	json, err := ParseJson(mock, "a", "b")
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	json.ArrayEach(func(jsonValue *JsonValue) error {
-		count++
+	json.ArrayEachWithIndex(func(idx int, jsonValue *JsonValue) {
 		value, _ := jsonValue.ParseString()
 
-		switch count {
-		case 1:
+		switch idx {
+		case 0:
 			if value != `{"x": 1}` {
 				t.Errorf("Wrong first item: %s", string(value))
 			}
-		case 2:
+		case 1:
 			if value != `{"x":2}` {
 				t.Errorf("Wrong second item: %s", string(value))
 			}
-		case 3:
+		case 2:
 			if value != `{ "x":3}` {
 				t.Errorf("Wrong third item: %s", string(value))
 			}
-		case 4:
+		case 3:
 			if value != `{"x":4}` {
 				t.Errorf("Wrong forth item: %s", string(value))
 			}
 		default:
 			t.Errorf("Should process only 4 items")
 		}
-		return nil
 	})
 }
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -798,7 +798,7 @@ func TestJsonValueArrayEach(t *testing.T) {
 		return
 	}
 	json.ArrayEachWithIndex(func(idx int, jsonValue *JsonValue) {
-		value, _ := jsonValue.ParseString()
+		value, _ := jsonValue.GetString()
 
 		switch idx {
 		case 0:

--- a/parser_test.go
+++ b/parser_test.go
@@ -680,8 +680,8 @@ func TestJsonValueGet(t *testing.T) {
 	runGetTests(t, "JsonValue.Get()", getTests,
 		func(test GetTest) (value interface{}, dataType ValueType, err error) {
 			//two steps to explicitly test JsonValue.Get(). (we could just pass the keys to ParseJson)
-			if json, err := ParseJson([]byte(test.json), test.path...); err != nil {
-				return nil, Unknown, err
+			if json := ParseJson([]byte(test.json), test.path...); json.Err() != nil {
+				return nil, Unknown, json.Err()
 			} else {
 				return json.data, json.Type, err
 			}
@@ -792,9 +792,9 @@ func TestArrayEach(t *testing.T) {
 func TestJsonValueArrayEach(t *testing.T) {
 	mock := []byte(`{"a": { "b":[{"x": 1} ,{"x":2},{ "x":3}, {"x":4} ]}}`)
 
-	json, err := ParseJson(mock, "a", "b")
-	if err != nil {
-		t.Error(err)
+	json := ParseJson(mock, "a", "b")
+	if json.Err() != nil {
+		t.Error(json.Err())
 		return
 	}
 	json.ArrayEachWithIndex(func(idx int, jsonValue *JsonValue) {


### PR DESCRIPTION
I was using the jsonparser to parse a deeply nested json with unknown format. I spent a lot of time reading the source code to figure out some bugs and edge cases I encountered while doing this.

To solve these issues I decided to make a small wrapper around the []byte, ValueType, error values the jsonparser functions return and use. Having this wrapped in an object makes it a lot easier to handle and allows a much nicer API, with the same speed as the base functions.

Issues I tried to solve with this:
- parsing nested structures recursively was very error prone, especially because when you use `Get` on something that gives you a json string, `Get` will unwrap the quotes and return a go string. This is not a valid json value anymore, so if you use `Get` on it again (or another function) it totally fails. This really was a big break of the jsonparser abstractions and meant I had to check for stuff like this everywhere.
- easier error management: the JsonValues implement the error interface. This allows you to chain a number of operations, without constant error checking. This way of error management was inspired by some of the built in go libraries, and really gives much much cleaner code.
- added better way to deal with ints and floats (on top of the Number ValueType)
- added integer overflow detection: when very large numbers were entered, they would just overflow in jsonparser and return a wrong go int64, while err==nil, which is very dangerous
- improve and simplify callback functions of the `Each` functions, to address some of the concers expressed in the jsonparser issues.
- allow using the standard go for loops to iterate over json arrays and objects. This allows for most control, which is not always possible with the callback functions.
- provide an entry point to also add writing of json, not only parsing


I edited the readme.md to reflect some of the changes the JsonValue abstaction allows. I spent a large amount of time refining these abstractions. I made sure no breaking changes to the existing base functions were introduced (which was not simply to solve the `Get` string quote stripping problem) and added unittests for all the new functionality. I've used and tested these additions in a project I'm working on.


I hope you would consider reviewing and adding the abstractions to the main github repo, as I think for most of the people looking for efficient json parsers the JsonValue API is a much simpler and easier to learn way to learn this library.

Thanks for all the great work on jsonparser, I really think it is the best parsing lib in its kind for go.