### PR TITLE
Return error rather than panicking on malformed json where there are …

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -289,6 +289,10 @@ func EachKey(data []byte, cb func(int, []byte, ValueType, error), paths ...[]str
 				}
 
 				if maxPath >= level {
+					if level < 1 {
+						cb(-1, []byte{}, Unknown, MalformedJsonError)
+						return -1
+					}
 					pathsBuf[level-1] = bytesToString(&keyUnesc)
 
 					for pi, p := range paths {

--- a/parser.go
+++ b/parser.go
@@ -343,6 +343,12 @@ func EachKey(data []byte, cb func(int, []byte, ValueType, error), paths ...[]str
 		case '[':
 			var arrIdxFlags int64
 			var pIdxFlags int64
+
+			if level < 0 {
+				cb(-1, []byte{}, Unknown, MalformedJsonError)
+				return -1
+			}
+
 			for pi, p := range paths {
 				if len(p) < level+1 || pathFlags&bitwiseFlags[pi+1] != 0 || p[level][0] != '[' || !sameTree(p, pathsBuf[:level]) {
 					continue


### PR DESCRIPTION
…more closing brackets than opening brackets

**Description**: Fixes issue #94 

**Benchmark after change**: Basically identical


For running benchmarks use:
```
go test -test.benchmem -bench JsonParser ./benchmark/ -benchtime 5s -v
# OR
make bench (runs inside docker)
```