### PR TITLE
Bugfix recursive object index

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -122,7 +122,6 @@ func searchKeys(data []byte, keys ...string) int {
 	}
 
 	var stackbuf [unescapeStackBufSize]byte // stack-allocated array for allocation-free unescaping of small strings
-
 	for i < ln {
 		switch data[i] {
 		case '"':
@@ -195,7 +194,11 @@ func searchKeys(data []byte, keys ...string) int {
 				if valueFound == nil {
 					return -1
 				} else {
-					return i + valueOffset + searchKeys(valueFound, keys[level+1:]...)
+					subIndex := searchKeys(valueFound, keys[level+1:]...)
+					if subIndex < 0 {
+						return -1
+					}
+					return i + valueOffset + subIndex
 				}
 			} else {
 				// Do not search for keys inside arrays

--- a/parser.go
+++ b/parser.go
@@ -122,6 +122,7 @@ func searchKeys(data []byte, keys ...string) int {
 	}
 
 	var stackbuf [unescapeStackBufSize]byte // stack-allocated array for allocation-free unescaping of small strings
+
 	for i < ln {
 		switch data[i] {
 		case '"':

--- a/parser_test.go
+++ b/parser_test.go
@@ -357,7 +357,19 @@ var getTests = []GetTest{
 		path:    []string{"b"},
 		isFound: false,
 	},
-
+	{ // Issue #81
+		desc:	`missing key in object in array`,
+		json: 	`{"p":{"a":[{"u":"abc","t":"th"}]}}`,
+		path: 	[]string{"p", "a", "[0]", "x"},
+		isFound: false,
+	},
+	{ // Issue #81 counter test
+		desc:	`existing key in object in array`,
+		json: 	`{"p":{"a":[{"u":"abc","t":"th"}]}}`,
+		path: 	[]string{"p", "a", "[0]", "u"},
+		isFound: true,
+		data:	"abc",
+	},
 	{ // This test returns not found instead of a parse error, as checking for the malformed JSON would reduce performance
 		desc:    "malformed key (followed by comma followed by colon)",
 		json:    `{"a",:1}`,
@@ -620,7 +632,6 @@ func runGetTests(t *testing.T, testKind string, tests []GetTest, runner func(Get
 		if activeTest != "" && test.desc != activeTest {
 			continue
 		}
-
 		fmt.Println("Running:", test.desc)
 
 		value, dataType, err := runner(test)

--- a/parser_test.go
+++ b/parser_test.go
@@ -632,6 +632,7 @@ func runGetTests(t *testing.T, testKind string, tests []GetTest, runner func(Get
 		if activeTest != "" && test.desc != activeTest {
 			continue
 		}
+
 		fmt.Println("Running:", test.desc)
 
 		value, dataType, err := runner(test)


### PR DESCRIPTION
**Description**: What this PR does
Fix issue #81 
Previously offset from nested searchKeys call was added to parent value such that 11 + (-1) would return a "successful" value of 10. I added logic to read the value of the nested call and return a failure as needed.

**Benchmark before change**:
BenchmarkJsonParserLarge-8                        200000             44154 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserMedium-8                      1000000              7197 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-8         2000000              4168 ns/op             112 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructMedium-8         2000000              4527 ns/op             656 B/op         13 allocs/op
BenchmarkJsonParserObjectEachStructMedium-8      1000000              7091 ns/op             608 B/op         12 allocs/op
BenchmarkJsonParserSmall-8                      10000000               605 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-8         20000000               445 ns/op              80 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructSmall-8         10000000               684 ns/op             256 B/op          9 allocs/op
BenchmarkJsonParserObjectEachStructSmall-8      20000000               596 ns/op             240 B/op          8 allocs/op

**Benchmark after change**:
BenchmarkJsonParserLarge-8                        200000             44139 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserMedium-8                      1000000              7075 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-8         2000000              4161 ns/op             112 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructMedium-8         2000000              4524 ns/op             656 B/op         13 allocs/op
BenchmarkJsonParserObjectEachStructMedium-8      1000000              7056 ns/op             608 B/op         12 allocs/op
BenchmarkJsonParserSmall-8                      10000000               604 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-8         20000000               445 ns/op              80 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructSmall-8         10000000               682 ns/op             256 B/op          9 allocs/op
BenchmarkJsonParserObjectEachStructSmall-8      20000000               598 ns/op             240 B/op          8 allocs/op