### PR TITLE
error handling while calling strconv.Atoi() while getting array element by index

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -178,8 +178,10 @@ func searchKeys(data []byte, keys ...string) int {
 		case '[':
 			// If we want to get array element by index
 			if keyLevel == level && keys[level][0] == '[' {
-				aIdx, _ := strconv.Atoi(keys[level][1 : len(keys[level])-1])
-
+				aIdx, err := strconv.Atoi(keys[level][1 : len(keys[level])-1])
+				if err != nil {
+					return -1
+				}
 				var curIdx int
 				var valueFound []byte
 				var valueOffset int


### PR DESCRIPTION
This error needs to be handled otherwise we can put string value in between [] while fetching array elements.

**Description**: What this PR does
This error needs to be handled for cases like 
`jsonparser.Get(data, "array", [random]) //square brackets will take string in between`

**Benchmark before change**:

**Benchmark after change**:


For running benchmarks use:
```
go test -test.benchmem -bench JsonParser ./benchmark/ -benchtime 5s -v
# OR
make bench (runs inside docker)
```