### PR TITLE
Add initial Set implementation #61

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,20 @@ jsonparser.EachKey(smallFixture, func(idx int, value []byte, vt jsonparser.Value
 }, paths...)
 ```
 
+### **`Set`**
+```go
+func Set(data []byte, setValue []byte, keys ...string) (value []byte, err error)
+```
+Receives existing data structure, key path to set, and value to set at that key. *This functionality is experimental.*
+
+Returns:
+* `value` - Pointer to original data structure with updated or added key value.
+* `err` - If any parsing issue, it should return error.
+
+Accepts multiple keys to specify path to JSON value (in case of updating or creating  nested structures).
+
+Note that keys can be an array indexes: `jsonparser.Set(data, []byte("http://github.com"), "person", "avatars", "[0]", "url")`
+
 
 ## What makes it so fast?
 * It does not rely on `encoding/json`, `reflection` or `interface{}`, the only real package dependency is `bytes`.

--- a/benchmark/benchmark_small_payload_test.go
+++ b/benchmark/benchmark_small_payload_test.go
@@ -129,6 +129,17 @@ func BenchmarkJsonParserObjectEachStructSmall(b *testing.B) {
 	}
 }
 
+func BenchmarkJsonParserSetSmall(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		jsonparser.Set(smallFixture, []byte(`"c90927dd-1588-4fe7-a14f-8a8950cfcbd8"`), "uuid")
+		jsonparser.Set(smallFixture, []byte("-3"), "tz")
+		jsonparser.Set(smallFixture, []byte(`"server_agent"`), "ua")
+		jsonparser.Set(smallFixture, []byte("3"), "st")
+
+		nothing()
+	}
+}
+
 /*
    encoding/json
 */
@@ -180,6 +191,19 @@ func BenchmarkGoSimplejsonSmall(b *testing.B) {
 		json.Get("tz").Float64()
 		json.Get("ua").String()
 		json.Get("st").Float64()
+
+		nothing()
+	}
+}
+
+func BenchmarkGoSimplejsonSetSmall(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		json, _ := simplejson.NewJson(smallFixture)
+
+		json.SetPath([]string{"uuid"}, "c90927dd-1588-4fe7-a14f-8a8950cfcbd8")
+		json.SetPath([]string{"tz"}, -3)
+		json.SetPath([]string{"ua"}, "server_agent")
+		json.SetPath([]string{"st"}, 3)
 
 		nothing()
 	}


### PR DESCRIPTION
**Description**:
This PR adds support for `Set` method, enabling end users to use jsonparser to generate json efficiently.
_Note: I am taking this over from #98 after discussion with @ryanleary as he does not have cycles to complete it at the moment._
**Benchmark before change**:
```
BenchmarkJsonParserLarge-4                         50000            170465 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserMedium-4                       200000             29789 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-4          500000             18119 ns/op             112 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructMedium-4          500000             21547 ns/op             656 B/op         13 allocs/op
BenchmarkJsonParserObjectEachStructMedium-4       200000             31427 ns/op             608 B/op         12 allocs/op
BenchmarkJsonParserSmall-4                       3000000              2414 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-4          3000000              2058 ns/op              80 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructSmall-4          2000000              3052 ns/op             256 B/op          9 allocs/op
BenchmarkJsonParserObjectEachStructSmall-4       3000000              2545 ns/op             240 B/op          8 allocs/op
```
**Benchmark after change**:
```
BenchmarkJsonParserLarge-4                         50000            147591 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserMedium-4                       300000             28021 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-4          500000             18563 ns/op             112 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructMedium-4          500000             19804 ns/op             656 B/op         13 allocs/op
BenchmarkJsonParserObjectEachStructMedium-4       300000             29924 ns/op             608 B/op         12 allocs/op
BenchmarkJsonParserSmall-4                       3000000              2089 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-4          3000000              2169 ns/op              80 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructSmall-4          2000000              3138 ns/op             256 B/op          9 allocs/op
BenchmarkJsonParserObjectEachStructSmall-4       3000000              2822 ns/op             240 B/op          8 allocs/op
BenchmarkJsonParserSetSmall-4                    2000000              4086 ns/op             816 B/op          5 allocs/op
```
Also note compare last to comparable `SetPath()` benchmark in `go-simplejson`:
```
BenchmarkGoSimplejsonSetSmall-4           500000             16755 ns/op            2289 B/op         40 allocs/op
```