### PR TITLE
Bugfix: Get() via index fails on string

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -183,11 +183,14 @@ func searchKeys(data []byte, keys ...string) int {
 				var curIdx int
 				var valueFound []byte
 				var valueOffset int
-
 				ArrayEach(data[i:], func(value []byte, dataType ValueType, offset int, err error) {
 					if curIdx == aIdx {
 						valueFound = value
 						valueOffset = offset
+                                                if dataType == String {
+							valueOffset = valueOffset - 2
+							valueFound = data[i + valueOffset:i + valueOffset + len(value) + 2]
+                                                }
 					}
 					curIdx += 1
 				})

--- a/parser_test.go
+++ b/parser_test.go
@@ -400,6 +400,13 @@ var getTests = []GetTest{
 		data:    `{"b":"2"}`,
 	},
 	{
+                desc:    "get string from array",
+                json:    `{"a":[{"b":1},"foo", 3],"c":{"c":[1,2]}}`,
+                path:    []string{"a", "[1]"},
+                isFound: true,
+                data:    "foo",
+        },
+	{
 		desc:    "key in path is index",
 		json:    `{"a":[{"b":"1"},{"b":"2"},3],"c":{"c":[1,2]}}`,
 		path:    []string{"a", "[0]", "b"},


### PR DESCRIPTION
**Description**:
This PR fixes bug where this test fails due to quotes being stripped prematurely from string, resulting in `UnknownValueTypeError`.
```
                desc:    "get string from array",
                json:    `{"a":[{"b":1},"foo", 3],"c":{"c":[1,2]}}`,
                path:    []string{"a", "[1]"},
                isFound: true,
                data:    "foo",
```

This is due to `searchKeys()` calling `ArrayEach()` to look up the index match, which calls `Get()`, which strips quotes from strings, resulting in `valueFound` pointing to string contents without quotes, which then looks like an unknown value type.

There may be a better suggested fix than the one I did (like just updating the offset directly in the slice), open to suggestions.