### PR TITLE
Bugfix: Characters in upper part of BMP would fail unescaping

### DIFF
--- a/escape_test.go
+++ b/escape_test.go
@@ -44,12 +44,14 @@ var singleUnicodeEscapeTests = append([]escapedUnicodeRuneTest{
 	{in: `\uD83D`, out: 0xD83D, len: 6},
 	{in: `\uDE03`, out: 0xDE03, len: 6},
 	{in: `\uFFFF`, out: 0xFFFF, len: 6},
+	{in: `\uFF11`, out: '１', len: 6},
 }, commonUnicodeEscapeTests...)
 
 var multiUnicodeEscapeTests = append([]escapedUnicodeRuneTest{
 	{in: `\uD83D`, isErr: true},
 	{in: `\uDE03`, isErr: true},
-	{in: `\uFFFF`, isErr: true},
+	{in: `\uFFFF`, out: '\uFFFF', len: 6},
+	{in: `\uFF11`, out: '１', len: 6},
 
 	{in: `\uD83D\uDE03`, out: '\U0001F603', len: 12},
 	{in: `\uD800\uDC00`, out: '\U00010000', len: 12},
@@ -109,13 +111,14 @@ var unescapeTests = []unescapeTest{
 	{in: `ab\\de`, out: `ab\de`, canAlloc: true},
 	{in: `ab\"de`, out: `ab"de`, canAlloc: true},
 	{in: `ab \u00B0 de`, out: `ab ° de`, canAlloc: true},
+	{in: `ab \uFF11 de`, out: `ab １ de`, canAlloc: true},
+	{in: `\uFFFF`, out: "\uFFFF", canAlloc: true},
 	{in: `ab \uD83D\uDE03 de`, out: "ab \U0001F603 de", canAlloc: true},
 	{in: `\u0000\u0000\u0000\u0000\u0000`, out: "\u0000\u0000\u0000\u0000\u0000", canAlloc: true},
 	{in: `\u0000 \u0000 \u0000 \u0000 \u0000`, out: "\u0000 \u0000 \u0000 \u0000 \u0000", canAlloc: true},
 	{in: ` \u0000 \u0000 \u0000 \u0000 \u0000 `, out: " \u0000 \u0000 \u0000 \u0000 \u0000 ", canAlloc: true},
 
 	{in: `\uD800`, isErr: true},
-	{in: `\uFFFF`, isErr: true},
 	{in: `abcde\`, isErr: true},
 	{in: `abcde\x`, isErr: true},
 	{in: `abcde\u`, isErr: true},

--- a/parser.go
+++ b/parser.go
@@ -832,7 +832,7 @@ func ParseBoolean(b []byte) (bool, error) {
 func ParseString(b []byte) (string, error) {
 	var stackbuf [unescapeStackBufSize]byte // stack-allocated array for allocation-free unescaping of small strings
 	if bU, err := Unescape(b, stackbuf[:]); err != nil {
-		return "", nil
+		return "", MalformedValueError
 	} else {
 		return string(bU), nil
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -358,17 +358,17 @@ var getTests = []GetTest{
 		isFound: false,
 	},
 	{ // Issue #81
-		desc:	`missing key in object in array`,
-		json: 	`{"p":{"a":[{"u":"abc","t":"th"}]}}`,
-		path: 	[]string{"p", "a", "[0]", "x"},
+		desc:    `missing key in object in array`,
+		json:    `{"p":{"a":[{"u":"abc","t":"th"}]}}`,
+		path:    []string{"p", "a", "[0]", "x"},
 		isFound: false,
 	},
 	{ // Issue #81 counter test
-		desc:	`existing key in object in array`,
-		json: 	`{"p":{"a":[{"u":"abc","t":"th"}]}}`,
-		path: 	[]string{"p", "a", "[0]", "u"},
+		desc:    `existing key in object in array`,
+		json:    `{"p":{"a":[{"u":"abc","t":"th"}]}}`,
+		path:    []string{"p", "a", "[0]", "u"},
 		isFound: true,
-		data:	"abc",
+		data:    "abc",
 	},
 	{ // This test returns not found instead of a parse error, as checking for the malformed JSON would reduce performance
 		desc:    "malformed key (followed by comma followed by colon)",
@@ -1180,6 +1180,36 @@ func TestParseFloat(t *testing.T) {
 		func(test ParseTest, obtained interface{}) (bool, interface{}) {
 			expected := test.out.(float64)
 			return obtained.(float64) == expected, expected
+		},
+	)
+}
+
+var parseStringTest = []ParseTest{
+	{
+		in:     `\uFF11`,
+		intype: String,
+		out:    "\uFF11",
+	},
+	{
+		in:     `\uFFFF`,
+		intype: String,
+		out:    "\uFFFF",
+	},
+	{
+		in:     `\uDF00`,
+		intype: String,
+		isErr:  true,
+	},
+}
+
+func TestParseString(t *testing.T) {
+	runParseTests(t, "ParseString()", parseStringTest,
+		func(test ParseTest) (value interface{}, err error) {
+			return ParseString([]byte(test.in))
+		},
+		func(test ParseTest, obtained interface{}) (bool, interface{}) {
+			expected := test.out.(string)
+			return obtained.(string) == expected, expected
 		},
 	)
 }


### PR DESCRIPTION
**Description**: 
When escaping characters in the upper part (`]\uDFFF-\uFFFF[`) of the Basic Multilingual Plane (BMP), the `decodeUnicodeEscape` would fail to see that this was a single rune instead of complex UTF16 rune.
When checking for single rune we now check if correctly if the single rune is within the complete space of BMP `[\u0000-\uFFFF[` and that its not in `[\uD800-uDFFF]`.

Furthermore I've fixed a bug in ParseString, such that if a unescape error happens a `MalformedValueError` is returned. I've also added unit test for ParseString.

NB: To run the benchmarks in the docker container i changed the Dockerfile to use `golang:1.8` instead of `golang:1.6`.

**Benchmark before change**:
BenchmarkJsonParserLarge-4                    	  200000	     58070 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserMedium-4                   	 1000000	     10187 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-4      	 1000000	      6662 ns/op	     112 B/op	       2 allocs/op
BenchmarkJsonParserEachKeyStructMedium-4      	 1000000	      6941 ns/op	     704 B/op	      13 allocs/op
BenchmarkJsonParserObjectEachStructMedium-4   	 1000000	      9475 ns/op	     656 B/op	      12 allocs/op
BenchmarkJsonParserSmall-4                    	10000000	       869 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-4       	10000000	       695 ns/op	      80 B/op	       2 allocs/op
BenchmarkJsonParserEachKeyStructSmall-4       	10000000	       972 ns/op	     256 B/op	       9 allocs/op
BenchmarkJsonParserObjectEachStructSmall-4    	10000000	       829 ns/op	     240 B/op	       8 allocs/op

**Benchmark after change**:
BenchmarkJsonParserLarge-4                    	  100000	     65712 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserMedium-4                   	 1000000	     10498 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-4      	 1000000	      6568 ns/op	     112 B/op	       2 allocs/op
BenchmarkJsonParserEachKeyStructMedium-4      	 1000000	      7012 ns/op	     704 B/op	      13 allocs/op
BenchmarkJsonParserObjectEachStructMedium-4   	 1000000	      9974 ns/op	     656 B/op	      12 allocs/op
BenchmarkJsonParserSmall-4                    	10000000	       917 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-4       	10000000	       670 ns/op	      80 B/op	       2 allocs/op
BenchmarkJsonParserEachKeyStructSmall-4       	10000000	       955 ns/op	     256 B/op	       9 allocs/op
BenchmarkJsonParserObjectEachStructSmall-4    	10000000	       827 ns/op	     240 B/op	       8 allocs/op


For running benchmarks use:
```
go test -test.benchmem -bench JsonParser ./benchmark/ -benchtime 5s -v
# OR
make bench (runs inside docker)
```