### PR TITLE
Add delete implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 *.mprof
 
 vendor/github.com/buger/goterm/
+prof.cpu
+prof.mem

--- a/README.md
+++ b/README.md
@@ -215,6 +215,19 @@ Accepts multiple keys to specify path to JSON value (in case of updating or crea
 
 Note that keys can be an array indexes: `jsonparser.Set(data, []byte("http://github.com"), "person", "avatars", "[0]", "url")`
 
+### **`Delete`**
+```go
+func Delete(data []byte, keys ...string) value []byte
+```
+Receives existing data structure, and key path to delete. *This functionality is experimental.*
+
+Returns:
+* `value` - Pointer to original data structure with key path deleted if it can be found. If there is no key path, then the whole data structure is deleted.
+
+Accepts multiple keys to specify path to JSON value (in case of updating or creating  nested structures).
+
+Note that keys can be an array indexes: `jsonparser.Delete(data, "person", "avatars", "[0]", "url")`
+
 
 ## What makes it so fast?
 * It does not rely on `encoding/json`, `reflection` or `interface{}`, the only real package dependency is `bytes`.
@@ -248,7 +261,7 @@ If you want to skip next sections we have 2 winner: `jsonparser` and `easyjson`.
 
 It's hard to fully compare `jsonparser` and `easyjson` (or `ffson`), they a true parsers and fully process record, unlike `jsonparser` which parse only keys you specified.
 
-If you searching for replacement of `encoding/json` while keeping structs, `easyjson` is an amazing choise. If you want to process dynamic JSON, have memory constrains, or more control over your data you should try `jsonparser`.
+If you searching for replacement of `encoding/json` while keeping structs, `easyjson` is an amazing choice. If you want to process dynamic JSON, have memory constrains, or more control over your data you should try `jsonparser`.
 
 `jsonparser` performance heavily depends on usage, and it works best when you do not need to process full record, only some keys. The more calls you need to make, the slower it will be, in contrast `easyjson` (or `ffjson`, `encoding/json`) parser record only 1 time, and then you can make as many calls as you want.
 
@@ -324,7 +337,7 @@ https://github.com/buger/jsonparser/blob/master/benchmark/benchmark_large_payloa
 | mailru/easyjson | **154186** | **6992** | **288** |
 | buger/jsonparser | **85308** | **0** | **0** |
 
-`jsonparser` now is a winner, but do not forget that it is way more lighweight parser than `ffson` or `easyjson`, and they have to parser all the data, while `jsonparser` parse only what you need. All `ffjson`, `easysjon` and `jsonparser` have their own parsing code, and does not depend on `encoding/json` or `interface{}`, thats one of the reasons why they are so fast. `easyjson` also use a bit of `unsafe` package to reduce memory consuption (in theory it can lead to some unexpected GC issue, but i did not tested enough)
+`jsonparser` now is a winner, but do not forget that it is way more lightweight parser than `ffson` or `easyjson`, and they have to parser all the data, while `jsonparser` parse only what you need. All `ffjson`, `easysjon` and `jsonparser` have their own parsing code, and does not depend on `encoding/json` or `interface{}`, thats one of the reasons why they are so fast. `easyjson` also use a bit of `unsafe` package to reduce memory consuption (in theory it can lead to some unexpected GC issue, but i did not tested enough)
 
 Also last benchmark did not included `EachKey` test, because in this particular case we need to read lot of Array values, and using `ArrayEach` is more efficient. 
 

--- a/benchmark/benchmark_medium_payload_test.go
+++ b/benchmark/benchmark_medium_payload_test.go
@@ -6,6 +6,8 @@ package benchmark
 
 import (
 	"encoding/json"
+	"testing"
+
 	"github.com/Jeffail/gabs"
 	"github.com/a8m/djson"
 	"github.com/antonholmquist/jason"
@@ -15,7 +17,6 @@ import (
 	"github.com/mreiferson/go-ujson"
 	"github.com/pquerna/ffjson/ffjson"
 	"github.com/ugorji/go/codec"
-	"testing"
 	// "fmt"
 	"bytes"
 	"errors"
@@ -34,6 +35,19 @@ func BenchmarkJsonParserMedium(b *testing.B) {
 			jsonparser.Get(value, "url")
 			nothing()
 		}, "person", "gravatar", "avatars")
+	}
+}
+
+func BenchmarkJsonParserDelMedium(b *testing.B) {
+	fixture := make([]byte, 0, len(mediumFixture))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		fixture = append(fixture[:0], mediumFixture...)
+		fixture = jsonparser.Del(fixture, "person", "name", "fullName")
+		fixture = jsonparser.Del(fixture, "person", "github", "followers")
+		fixture = jsonparser.Del(fixture, "company")
+
+		nothing()
 	}
 }
 

--- a/benchmark/benchmark_medium_payload_test.go
+++ b/benchmark/benchmark_medium_payload_test.go
@@ -38,14 +38,14 @@ func BenchmarkJsonParserMedium(b *testing.B) {
 	}
 }
 
-func BenchmarkJsonParserDelMedium(b *testing.B) {
+func BenchmarkJsonParserDeleteMedium(b *testing.B) {
 	fixture := make([]byte, 0, len(mediumFixture))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		fixture = append(fixture[:0], mediumFixture...)
-		fixture = jsonparser.Del(fixture, "person", "name", "fullName")
-		fixture = jsonparser.Del(fixture, "person", "github", "followers")
-		fixture = jsonparser.Del(fixture, "company")
+		fixture = jsonparser.Delete(fixture, "person", "name", "fullName")
+		fixture = jsonparser.Delete(fixture, "person", "github", "followers")
+		fixture = jsonparser.Delete(fixture, "company")
 
 		nothing()
 	}

--- a/benchmark/benchmark_small_payload_test.go
+++ b/benchmark/benchmark_small_payload_test.go
@@ -147,10 +147,10 @@ func BenchmarkJsonParserDelSmall(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		fixture = append(fixture[:0], smallFixture...)
-		fixture = jsonparser.Del(fixture, "uuid")
-		fixture = jsonparser.Del(fixture, "tz")
-		fixture = jsonparser.Del(fixture, "ua")
-		fixture = jsonparser.Del(fixture, "stt")
+		fixture = jsonparser.Delete(fixture, "uuid")
+		fixture = jsonparser.Delete(fixture, "tz")
+		fixture = jsonparser.Delete(fixture, "ua")
+		fixture = jsonparser.Delete(fixture, "stt")
 
 		nothing()
 	}

--- a/benchmark/benchmark_small_payload_test.go
+++ b/benchmark/benchmark_small_payload_test.go
@@ -6,6 +6,8 @@ package benchmark
 
 import (
 	"encoding/json"
+	"testing"
+
 	"github.com/Jeffail/gabs"
 	"github.com/a8m/djson"
 	"github.com/antonholmquist/jason"
@@ -15,7 +17,6 @@ import (
 	"github.com/mreiferson/go-ujson"
 	"github.com/pquerna/ffjson/ffjson"
 	"github.com/ugorji/go/codec"
-	"testing"
 	// "fmt"
 	"bytes"
 	"errors"
@@ -136,6 +137,20 @@ func BenchmarkJsonParserSetSmall(b *testing.B) {
 		jsonparser.Set(smallFixture, []byte("-3"), "tz")
 		jsonparser.Set(smallFixture, []byte(`"server_agent"`), "ua")
 		jsonparser.Set(smallFixture, []byte("3"), "st")
+
+		nothing()
+	}
+}
+
+func BenchmarkJsonParserDelSmall(b *testing.B) {
+	fixture := make([]byte, 0, len(smallFixture))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		fixture = append(fixture[:0], smallFixture...)
+		fixture = jsonparser.Del(fixture, "uuid")
+		fixture = jsonparser.Del(fixture, "tz")
+		fixture = jsonparser.Del(fixture, "ua")
+		fixture = jsonparser.Del(fixture, "stt")
 
 		nothing()
 	}

--- a/bytes_safe.go
+++ b/bytes_safe.go
@@ -19,3 +19,7 @@ func parseFloat(b *[]byte) (float64, error) {
 func bytesToString(b *[]byte) string {
 	return string(*b)
 }
+
+func StringToBytes(s string) []byte {
+	return []byte(s)
+}

--- a/bytes_unsafe.go
+++ b/bytes_unsafe.go
@@ -3,6 +3,7 @@
 package jsonparser
 
 import (
+	"reflect"
 	"strconv"
 	"unsafe"
 )
@@ -16,16 +17,26 @@ import (
 //
 // TODO: Remove hack after Go 1.7 release
 //
-func equalStr(b []byte, s string) bool {
-	return *(*string)(unsafe.Pointer(&b)) == s
+func equalStr(b *[]byte, s string) bool {
+	return *(*string)(unsafe.Pointer(b)) == s
 }
 
-func parseFloat(b []byte) (float64, error) {
-	return strconv.ParseFloat(*(*string)(unsafe.Pointer(&b)), 64)
+func parseFloat(b *[]byte) (float64, error) {
+	return strconv.ParseFloat(*(*string)(unsafe.Pointer(b)), 64)
 }
 
 // A hack until issue golang/go#2632 is fixed.
 // See: https://github.com/golang/go/issues/2632
-func bytesToString(b []byte) string {
-	return *(*string)(unsafe.Pointer(&b))
+func bytesToString(b *[]byte) string {
+	return *(*string)(unsafe.Pointer(b))
+}
+
+func StringToBytes(s string) []byte {
+	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
+	bh := reflect.SliceHeader{
+		Data: sh.Data,
+		Len:  sh.Len,
+		Cap:  sh.Len,
+	}
+	return *(*[]byte)(unsafe.Pointer(&bh))
 }

--- a/bytes_unsafe.go
+++ b/bytes_unsafe.go
@@ -16,16 +16,16 @@ import (
 //
 // TODO: Remove hack after Go 1.7 release
 //
-func equalStr(b *[]byte, s string) bool {
-	return *(*string)(unsafe.Pointer(b)) == s
+func equalStr(b []byte, s string) bool {
+	return *(*string)(unsafe.Pointer(&b)) == s
 }
 
-func parseFloat(b *[]byte) (float64, error) {
-	return strconv.ParseFloat(*(*string)(unsafe.Pointer(b)), 64)
+func parseFloat(b []byte) (float64, error) {
+	return strconv.ParseFloat(*(*string)(unsafe.Pointer(&b)), 64)
 }
 
 // A hack until issue golang/go#2632 is fixed.
 // See: https://github.com/golang/go/issues/2632
-func bytesToString(b *[]byte) string {
-	return *(*string)(unsafe.Pointer(b))
+func bytesToString(b []byte) string {
+	return *(*string)(unsafe.Pointer(&b))
 }

--- a/bytes_unsafe_test.go
+++ b/bytes_unsafe_test.go
@@ -27,7 +27,7 @@ func bytesEqualStrUnsafeSlower(abytes *[]byte, bstr string) bool {
 }
 
 func TestEqual(t *testing.T) {
-	if !equalStr(&[]byte{}, "") {
+	if !equalStr([]byte{}, "") {
 		t.Errorf(`equalStr("", ""): expected true, obtained false`)
 		return
 	}
@@ -37,11 +37,11 @@ func TestEqual(t *testing.T) {
 		s1, s2 := longstr[:i]+"1", longstr[:i]+"2"
 		b1 := []byte(s1)
 
-		if !equalStr(&b1, s1) {
+		if !equalStr(b1, s1) {
 			t.Errorf(`equalStr("a"*%d + "1", "a"*%d + "1"): expected true, obtained false`, i, i)
 			break
 		}
-		if equalStr(&b1, s2) {
+		if equalStr(b1, s2) {
 			t.Errorf(`equalStr("a"*%d + "1", "a"*%d + "2"): expected false, obtained true`, i, i)
 			break
 		}
@@ -50,7 +50,7 @@ func TestEqual(t *testing.T) {
 
 func BenchmarkEqualStr(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		equalStr(&benchmarkBytes, benchmarkString)
+		equalStr(benchmarkBytes, benchmarkString)
 	}
 }
 

--- a/bytes_unsafe_test.go
+++ b/bytes_unsafe_test.go
@@ -27,7 +27,7 @@ func bytesEqualStrUnsafeSlower(abytes *[]byte, bstr string) bool {
 }
 
 func TestEqual(t *testing.T) {
-	if !equalStr([]byte{}, "") {
+	if !equalStr(&[]byte{}, "") {
 		t.Errorf(`equalStr("", ""): expected true, obtained false`)
 		return
 	}
@@ -37,11 +37,11 @@ func TestEqual(t *testing.T) {
 		s1, s2 := longstr[:i]+"1", longstr[:i]+"2"
 		b1 := []byte(s1)
 
-		if !equalStr(b1, s1) {
+		if !equalStr(&b1, s1) {
 			t.Errorf(`equalStr("a"*%d + "1", "a"*%d + "1"): expected true, obtained false`, i, i)
 			break
 		}
-		if equalStr(b1, s2) {
+		if equalStr(&b1, s2) {
 			t.Errorf(`equalStr("a"*%d + "1", "a"*%d + "2"): expected false, obtained true`, i, i)
 			break
 		}
@@ -50,7 +50,7 @@ func TestEqual(t *testing.T) {
 
 func BenchmarkEqualStr(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		equalStr(benchmarkBytes, benchmarkString)
+		equalStr(&benchmarkBytes, benchmarkString)
 	}
 }
 

--- a/parser.go
+++ b/parser.go
@@ -587,7 +587,7 @@ Returns:
 `data` - return modified data
 
 */
-func Del(data []byte, keys ...string) []byte {
+func Delete(data []byte, keys ...string) []byte {
 	lk := len(keys)
 	if lk == 0 {
 		return data[:0]

--- a/parser_test.go
+++ b/parser_test.go
@@ -50,7 +50,7 @@ type SetTest struct {
 	data interface{}
 }
 
-type DelTest struct {
+type DeleteTest struct {
 	desc string
 	json string
 	path []string
@@ -58,7 +58,7 @@ type DelTest struct {
 	data interface{}
 }
 
-var delTests = []DelTest{
+var deleteTests = []DeleteTest{
 	{
 		desc: "Delete test key",
 		json: `{"test":"input"}`,
@@ -975,7 +975,7 @@ func runSetTests(t *testing.T, testKind string, tests []SetTest, runner func(Set
 	}
 }
 
-func runDelTests(t *testing.T, testKind string, tests []DelTest, runner func(DelTest) interface{}, resultChecker func(DelTest, interface{}) (bool, interface{})) {
+func runDeleteTests(t *testing.T, testKind string, tests []DeleteTest, runner func(DeleteTest) interface{}, resultChecker func(DeleteTest, interface{}) (bool, interface{})) {
 	for _, test := range tests {
 		if activeTest != "" && test.desc != activeTest {
 			continue
@@ -1015,12 +1015,12 @@ func TestSet(t *testing.T) {
 	)
 }
 
-func TestDel(t *testing.T) {
-	runDelTests(t, "Del()", delTests,
-		func(test DelTest) interface{} {
-			return Del([]byte(test.json), test.path...)
+func TestDelete(t *testing.T) {
+	runDeleteTests(t, "Delete()", deleteTests,
+		func(test DeleteTest) interface{} {
+			return Delete([]byte(test.json), test.path...)
 		},
-		func(test DelTest, value interface{}) (bool, interface{}) {
+		func(test DeleteTest, value interface{}) (bool, interface{}) {
 			expected := []byte(test.data.(string))
 			return bytes.Equal(expected, value.([]byte)), expected
 		},


### PR DESCRIPTION
**Description**:

This pull request adds a delete method to jsonparser, allowing users to remove json at a given path.

**Benchmark before change**:
```
BenchmarkJsonParserLarge-4                    	  100000	     73291 ns/op	     752 B/op	      94 allocs/op
BenchmarkJsonParserMedium-4                   	  500000	     12786 ns/op	      40 B/op	       5 allocs/op
BenchmarkJsonParserEachKeyManualMedium-4      	 1000000	      7033 ns/op	     120 B/op	       3 allocs/op
BenchmarkJsonParserEachKeyStructMedium-4      	 1000000	      7535 ns/op	     672 B/op	      12 allocs/op
BenchmarkJsonParserObjectEachStructMedium-4   	  500000	     11908 ns/op	     664 B/op	      16 allocs/op
BenchmarkJsonParserSmall-4                    	10000000	      1179 ns/op	      32 B/op	       4 allocs/op
BenchmarkJsonParserEachKeyManualSmall-4       	10000000	       733 ns/op	      80 B/op	       2 allocs/op
BenchmarkJsonParserEachKeyStructSmall-4       	10000000	      1035 ns/op	     256 B/op	       9 allocs/op
BenchmarkJsonParserObjectEachStructSmall-4    	10000000	       915 ns/op	     240 B/op	       8 allocs/op
BenchmarkJsonParserSetSmall-4                 	 5000000	      1511 ns/op	     848 B/op	       9 allocs/op
PASS
ok  	github.com/buger/jsonparser/benchmark	87.053s
```
**Benchmark after change**:

```
BenchmarkJsonParserLarge-4                    	  100000	     60300 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserMedium-4                   	 1000000	     10371 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserDelMedium-4                	 1000000	      8493 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-4      	 1000000	      6847 ns/op	     112 B/op	       2 allocs/op
BenchmarkJsonParserEachKeyStructMedium-4      	 1000000	      7224 ns/op	     672 B/op	      12 allocs/op
BenchmarkJsonParserObjectEachStructMedium-4   	 1000000	     10331 ns/op	     624 B/op	      11 allocs/op
BenchmarkJsonParserSmall-4                    	10000000	       910 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-4       	10000000	       717 ns/op	      80 B/op	       2 allocs/op
BenchmarkJsonParserEachKeyStructSmall-4       	10000000	      1012 ns/op	     256 B/op	       9 allocs/op
BenchmarkJsonParserObjectEachStructSmall-4    	10000000	       910 ns/op	     240 B/op	       8 allocs/op
BenchmarkJsonParserSetSmall-4                 	 5000000	      1242 ns/op	     816 B/op	       5 allocs/op
BenchmarkJsonParserDelSmall-4                 	 5000000	      1511 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/buger/jsonparser/benchmark	106.127s
```