### PR TITLE
Add GJson to benchmark.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN go get github.com/antonholmquist/jason
 RUN go get github.com/mreiferson/go-ujson
 RUN go get -tags=unsafe -u github.com/ugorji/go/codec
 RUN go get github.com/mailru/easyjson
+RUN go get github.com/tidwall/gjson
 
 WORKDIR /go/src/github.com/buger/jsonparser
 ADD . /go/src/github.com/buger/jsonparser

--- a/benchmark/benchmark_large_payload_test.go
+++ b/benchmark/benchmark_large_payload_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/a8m/djson"
 	jlexer "github.com/mailru/easyjson/jlexer"
 	"github.com/pquerna/ffjson/ffjson"
+    "github.com/tidwall/gjson"
 	// "github.com/antonholmquist/jason"
 	// "fmt"
 )
@@ -127,5 +128,25 @@ func BenchmarkDjsonLarge(b *testing.B) {
 			tI := t.(map[string]interface{})
 			nothing(tI["id"].(float64), tI["slug"].(string))
 		}
+	}
+}
+
+/*
+	github.com/tidwall/gjson
+ */
+func BenchmarkGJsonLarge(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		gjson.GetBytes(largeFixture, "users").ForEach(func(key, value gjson.Result) bool {
+			value.Get("username")
+			nothing()
+			return true
+		})
+
+		gjson.GetBytes(largeFixture, "topics.topics").ForEach(func(key, value gjson.Result) bool {
+			value.Get("id").Int()
+			value.Get("slug")
+			nothing()
+			return true
+		})
 	}
 }

--- a/benchmark/benchmark_medium_payload_test.go
+++ b/benchmark/benchmark_medium_payload_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mreiferson/go-ujson"
 	"github.com/pquerna/ffjson/ffjson"
 	"github.com/ugorji/go/codec"
+    "github.com/tidwall/gjson"
 	// "fmt"
 	"bytes"
 	"errors"
@@ -349,5 +350,22 @@ func BenchmarkEasyJsonMedium(b *testing.B) {
 		for _, el := range data.Person.Gravatar.Avatars {
 			nothing(el.Url)
 		}
+	}
+}
+
+/*
+	github.com/tidwall/gjson
+ */
+func BenchmarkGJsonMedium(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		gjson.GetBytes(mediumFixture, "person.name.fullName")
+		gjson.GetBytes(mediumFixture, "person.github.followers").Int()
+		gjson.GetBytes(mediumFixture, "company")
+
+		gjson.GetBytes(mediumFixture, "person.gravatar.avatars").ForEach(func(key, value gjson.Result) bool {
+			value.Get("url")
+			nothing()
+			return true
+		})
 	}
 }

--- a/benchmark/benchmark_small_payload_test.go
+++ b/benchmark/benchmark_small_payload_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mreiferson/go-ujson"
 	"github.com/pquerna/ffjson/ffjson"
 	"github.com/ugorji/go/codec"
+    "github.com/tidwall/gjson"
 	// "fmt"
 	"bytes"
 	"errors"
@@ -304,5 +305,19 @@ func BenchmarkEasyJsonSmall(b *testing.B) {
 		data.UnmarshalEasyJSON(lexer)
 
 		nothing(data.Uuid, data.Tz, data.Ua, data.St)
+	}
+}
+
+/*
+	github.com/tidwall/gjson
+ */
+func BenchmarkGJsonSmall(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		gjson.GetBytes(smallFixture, "uuid");
+		gjson.GetBytes(smallFixture, "tz").Int()
+		gjson.GetBytes(smallFixture, "ua")
+		gjson.GetBytes(smallFixture, "st").Int()
+
+		nothing()
 	}
 }


### PR DESCRIPTION
**Description**: What this PR does

PR adds the GJson library to the benchmark.

**Benchmark before change**:

> go test -test.benchmem -bench "(JsonParser|EncodingJsonStruct|Gabs|GoSimplejson|FFJson|Jason|Ujson|Djson|Ugirji|EasyJson|GJson)(Small|Medium|Large)" ./benchmark/ -benchtime 5s -v

```
BenchmarkGJsonLarge-8                      20000            353167 ns/op           28672 B/op          2 allocs/op
BenchmarkJsonParserLarge-8                 50000            195840 ns/op               0 B/op          0 allocs/op
BenchmarkEncodingJsonStructLarge-8         10000           1033321 ns/op            8294 B/op        307 allocs/op
BenchmarkFFJsonLarge-8                     20000            450259 ns/op            7814 B/op        298 allocs/op
BenchmarkEasyJsonLarge-8                   30000            272045 ns/op            6992 B/op        288 allocs/op
BenchmarkDjsonLarge-8                      10000           1081068 ns/op          213693 B/op       3086 allocs/op

BenchmarkGJsonMedium-8                    200000             33240 ns/op             168 B/op          4 allocs/op
BenchmarkJsonParserMedium-8               200000             36624 ns/op               0 B/op          0 allocs/op
BenchmarkEncodingJsonStructMedium-8       100000             89438 ns/op            1353 B/op         29 allocs/op
BenchmarkGabsMedium-8                      50000            121465 ns/op           11204 B/op        235 allocs/op
BenchmarkFFJsonMedium-8                   200000             32352 ns/op             872 B/op         20 allocs/op
BenchmarkJasonMedium-8                     50000            134200 ns/op           19013 B/op        247 allocs/op
BenchmarkUjsonMedium-8                    100000             84952 ns/op           11547 B/op        270 allocs/op
BenchmarkDjsonMedium-8                    100000             62906 ns/op           10194 B/op        199 allocs/op
BenchmarkUgirjiMedium-8                    50000            178454 ns/op            6749 B/op        152 allocs/op
BenchmarkEasyJsonMedium-8                 300000             22719 ns/op             336 B/op         12 allocs/op

BenchmarkGJsonSmall-8                    2000000              3641 ns/op              64 B/op          4 allocs/op
BenchmarkJsonParserSmall-8               2000000              3393 ns/op               0 B/op          0 allocs/op
BenchmarkEncodingJsonStructSmall-8        500000             13518 ns/op             896 B/op         18 allocs/op
BenchmarkGabsSmall-8                      500000             16520 ns/op            1649 B/op         46 allocs/op
BenchmarkGoSimplejsonSmall-8              500000             17106 ns/op            2241 B/op         36 allocs/op
BenchmarkFFJsonSmall-8                   1000000              6685 ns/op             640 B/op         15 allocs/op
BenchmarkJasonSmall-8                     200000             43988 ns/op            7237 B/op        101 allocs/op
BenchmarkUjsonSmall-8                    1000000             11008 ns/op            1409 B/op         37 allocs/op
BenchmarkDjsonSmall-8                    1000000              7788 ns/op            1249 B/op         30 allocs/op
BenchmarkUgirjiSmall-8                    500000             14436 ns/op            2192 B/op         31 allocs/op
BenchmarkEasyJsonSmall-8                 2000000              3424 ns/op             192 B/op          9 allocs/op
```