### PR TITLE
Fix Delete()

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -52,6 +52,9 @@ func findTokenStart(data []byte, token byte) int {
 func findKeyStart(data []byte, key string) (int, error) {
 	i := 0
 	ln := len(data)
+	if ln > 0 && (data[0] == '{' || data[0] == '[') {
+		i = 1
+	}
 	var stackbuf [unescapeStackBufSize]byte // stack-allocated array for allocation-free unescaping of small strings
 
 	if ku, err := Unescape(StringToBytes(key), stackbuf[:]); err == nil {
@@ -94,6 +97,10 @@ func findKeyStart(data []byte, key string) (int, error) {
 				return keyBegin - 1, nil
 			}
 
+		case '[':
+			i = blockEnd(data[i:], data[i], ']') + i
+		case '{':
+			i = blockEnd(data[i:], data[i], '}') + i
 		}
 		i++
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -143,6 +143,30 @@ var deleteTests = []DeleteTest{
 		path: []string{"b"},
 		data: `{"a":}`,
 	},
+	{
+		desc: "Delete object without inner array",
+		json: `{"a": {"b": 1}, "b": 2}`,
+		path: []string{"b"},
+		data: `{"a": {"b": 1}}`,
+	},
+	{
+		desc: "Delete object without inner array",
+		json: `{"a": [{"b": 1}], "b": 2}`,
+		path: []string{"b"},
+		data: `{"a": [{"b": 1}]}`,
+	},
+	{
+		desc: "Delete object without inner array",
+		json: `{"a": {"c": {"b": 3}, "b": 1}, "b": 2}`,
+		path: []string{"a", "b"},
+		data: `{"a": {"c": {"b": 3}}, "b": 2}`,
+	},
+	{
+		desc: "Delete object without inner array",
+		json: `{"a": [{"c": {"b": 3}, "b": 1}], "b": 2}`,
+		path: []string{"a", "[0]", "b"},
+		data: `{"a": [{"c": {"b": 3}}], "b": 2}`,
+	},
 }
 
 var setTests = []SetTest{


### PR DESCRIPTION
**Description**: fix Delete() method #123

**Benchmark before change**:
```
BenchmarkJsonParserLarge-4                    	  200000	     49941 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserMedium-4                   	 1000000	      7363 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserDeleteMedium-4             	 1000000	      6219 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-4      	 1000000	      5056 ns/op	     112 B/op	       2 allocs/op
BenchmarkJsonParserEachKeyStructMedium-4      	 1000000	      5781 ns/op	     672 B/op	      12 allocs/op
BenchmarkJsonParserObjectEachStructMedium-4   	 1000000	      8082 ns/op	     624 B/op	      11 allocs/op
BenchmarkJsonParserSmall-4                    	10000000	       784 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-4       	10000000	       649 ns/op	      80 B/op	       2 allocs/op
BenchmarkJsonParserEachKeyStructSmall-4       	10000000	       744 ns/op	     144 B/op	       4 allocs/op
BenchmarkJsonParserObjectEachStructSmall-4    	10000000	       658 ns/op	     128 B/op	       3 allocs/op
BenchmarkJsonParserSetSmall-4                 	10000000	      1156 ns/op	     816 B/op	       5 allocs/op
BenchmarkJsonParserDelSmall-4                 	 5000000	      1295 ns/op	       0 B/op	       0 allocs/op
```

**Benchmark after change**:
```
BenchmarkJsonParserLarge-4                    	  200000	     50000 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserMedium-4                   	 1000000	      8386 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserDeleteMedium-4             	 1000000	      8880 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-4      	 1000000	      5167 ns/op	     112 B/op	       2 allocs/op
BenchmarkJsonParserEachKeyStructMedium-4      	 1000000	      6114 ns/op	     672 B/op	      12 allocs/op
BenchmarkJsonParserObjectEachStructMedium-4   	 1000000	      8756 ns/op	     624 B/op	      11 allocs/op
BenchmarkJsonParserSmall-4                    	10000000	       841 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-4       	10000000	       648 ns/op	      80 B/op	       2 allocs/op
BenchmarkJsonParserEachKeyStructSmall-4       	10000000	       797 ns/op	     144 B/op	       4 allocs/op
BenchmarkJsonParserObjectEachStructSmall-4    	10000000	       660 ns/op	     128 B/op	       3 allocs/op
BenchmarkJsonParserSetSmall-4                 	 5000000	      1265 ns/op	     816 B/op	       5 allocs/op
BenchmarkJsonParserDelSmall-4                 	 5000000	      1453 ns/op	       0 B/op	       0 allocs/op
```

**Diff benchmarks (benchcmp)**:
```
benchmark                                       old ns/op     new ns/op     delta
BenchmarkJsonParserLarge-4                      49941         50000         +0.12%
BenchmarkJsonParserMedium-4                     7363          8386          +13.89%
BenchmarkJsonParserDeleteMedium-4               6219          8880          +42.79%
BenchmarkJsonParserEachKeyManualMedium-4        5056          5167          +2.20%
BenchmarkJsonParserEachKeyStructMedium-4        5781          6114          +5.76%
BenchmarkJsonParserObjectEachStructMedium-4     8082          8756          +8.34%
BenchmarkJsonParserSmall-4                      784           841           +7.27%
BenchmarkJsonParserEachKeyManualSmall-4         649           648           -0.15%
BenchmarkJsonParserEachKeyStructSmall-4         744           797           +7.12%
BenchmarkJsonParserObjectEachStructSmall-4      658           660           +0.30%
BenchmarkJsonParserSetSmall-4                   1156          1265          +9.43%
BenchmarkJsonParserDelSmall-4                   1295          1453          +12.20%
```
