### PR TITLE
Trailing commas should be removed when last item in the object is deleted

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -648,16 +648,20 @@ func Delete(data []byte, keys ...string) []byte {
 		} else if data[endOffset+tokEnd] == "]"[0] && data[tokStart] == ","[0] {
 			keyOffset = tokStart
 		}
-
 	}
 
-	// We need to remove empty row and remaining trailing comma if we delete las element in the objects
+	// We need to remove remaining trailing comma if we delete las element in the object
 	prevTok := lastToken(data[:keyOffset])
-	if data[nextToken(data[endOffset:])] == '}' && data[prevTok] == ',' {
-		prevTok--
+	remainedValue := data[endOffset:]
+
+	var newOffset int
+	if nextToken(remainedValue) > -1 && remainedValue[nextToken(remainedValue)] == '}' && data[prevTok] == ',' {
+		newOffset = prevTok
+	} else {
+		newOffset = keyOffset
 	}
 
-	data = append(data[:prevTok], data[endOffset:]...)
+	data = append(data[:newOffset], data[endOffset:]...)
 	return data
 }
 

--- a/parser.go
+++ b/parser.go
@@ -658,7 +658,7 @@ func Delete(data []byte, keys ...string) []byte {
 	if nextToken(remainedValue) > -1 && remainedValue[nextToken(remainedValue)] == '}' && data[prevTok] == ',' {
 		newOffset = prevTok
 	} else {
-		newOffset = keyOffset
+		newOffset = prevTok + 1
 	}
 
 	data = append(data[:newOffset], data[endOffset:]...)

--- a/parser.go
+++ b/parser.go
@@ -648,9 +648,16 @@ func Delete(data []byte, keys ...string) []byte {
 		} else if data[endOffset+tokEnd] == "]"[0] && data[tokStart] == ","[0] {
 			keyOffset = tokStart
 		}
+
 	}
 
-	data = append(data[:keyOffset], data[endOffset:]...)
+	// We need to remove empty row and remaining trailing comma if we delete las element in the objects
+	prevTok := lastToken(data[:keyOffset])
+	if data[nextToken(data[endOffset:])] == '}' && data[prevTok] == ',' {
+		prevTok--
+	}
+
+	data = append(data[:prevTok], data[endOffset:]...)
 	return data
 }
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -167,6 +167,12 @@ var deleteTests = []DeleteTest{
 		path: []string{"a", "[0]", "b"},
 		data: `{"a": [{"c": {"b": 3}}], "b": 2}`,
 	},
+	{
+		desc: "Remove trailing comma if last object is deleted",
+		json: `{"a": "1", "b": "2"}`,
+		path: []string{"b"},
+		data: `{"a": "1"}`,
+	},
 }
 
 var setTests = []SetTest{


### PR DESCRIPTION
**Description**: 
Right now when last item in object is deleted, trailing commas remain and make json invalid.

For example: 
Given such a json: 
```{ "a": "1", "b": "2"}```

If we delete `b` key then the result will be: 
```{ "a": "1",}```

This makes json invalid. In this PR I've fixed it.

**Benchmark before change**:
```
BenchmarkJsonParserLarge-4                        100000             69483 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserMedium-4                      1000000             11553 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserDeleteMedium-4                 500000             11788 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-4         1000000              7436 ns/op             112 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructMedium-4         1000000              7962 ns/op             672 B/op         12 allocs/op
BenchmarkJsonParserObjectEachStructMedium-4      1000000             11725 ns/op             624 B/op         11 allocs/op
BenchmarkJsonParserSmall-4                      10000000              1535 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-4         10000000               869 ns/op              80 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructSmall-4         10000000              1074 ns/op             144 B/op          4 allocs/op
BenchmarkJsonParserObjectEachStructSmall-4      10000000               921 ns/op             128 B/op          3 allocs/op
BenchmarkJsonParserSetSmall-4                    5000000              1534 ns/op             816 B/op          5 allocs/op
BenchmarkJsonParserDelSmall-4                    3000000              2035 ns/op               0 B/op          0 allocs/op
```

**Benchmark after change**:

```
BenchmarkJsonParserLarge-4                        100000             65019 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserMedium-4                      1000000             11508 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserDeleteMedium-4                 500000             13632 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-4         1000000              6767 ns/op             112 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructMedium-4         1000000              7821 ns/op             672 B/op         12 allocs/op
BenchmarkJsonParserObjectEachStructMedium-4      1000000             11342 ns/op             624 B/op         11 allocs/op
BenchmarkJsonParserSmall-4                      10000000              1125 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-4         10000000               883 ns/op              80 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructSmall-4         10000000              1072 ns/op             144 B/op          4 allocs/op
BenchmarkJsonParserObjectEachStructSmall-4      10000000               852 ns/op             128 B/op          3 allocs/op
BenchmarkJsonParserSetSmall-4                    5000000              1601 ns/op             816 B/op          5 allocs/op
BenchmarkJsonParserDelSmall-4                    5000000              1986 ns/op               0 B/op          0 allocs/op
```


For running benchmarks use:
```
go test -test.benchmem -bench JsonParser ./benchmark/ -benchtime 5s -v
# OR
make bench (runs inside docker)
```