### PR TITLE
Correctly handle space-comma case in Delete

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -648,6 +648,8 @@ func Delete(data []byte, keys ...string) []byte {
 
 		if data[endOffset+tokEnd] == ","[0] {
 			endOffset += tokEnd + 1
+		} else if data[endOffset+tokEnd] == " "[0] && len(data) > endOffset+tokEnd+1 && data[endOffset+tokEnd+1] == ","[0] {
+			endOffset += tokEnd + 2
 		} else if data[endOffset+tokEnd] == "}"[0] && data[tokStart] == ","[0] {
 			keyOffset = tokStart
 		}

--- a/parser_test.go
+++ b/parser_test.go
@@ -173,6 +173,18 @@ var deleteTests = []DeleteTest{
 		path: []string{"b"},
 		data: `{"a": "1"}`,
 	},
+	{
+		desc: "Correctly delete first element with space-comma",
+		json: `{"a": "1" ,"b": "2" }`,
+		path: []string{"a"},
+		data: `{"b": "2" }`,
+	},
+	{
+		desc: "Correctly delete middle element with space-comma",
+		json: `{"a": "1" ,"b": "2" , "c": 3}`,
+		path: []string{"b"},
+		data: `{"a": "1" , "c": 3}`,
+	},
 }
 
 var setTests = []SetTest{


### PR DESCRIPTION
This change makes sure `{"a": "1" ,"b": "2" }` does not end up as `{ ,"b": "2" }`, but as `{"b": "2" }`, when deleting `b`.

I didn't dig too deep into the code, so I could be tackling this at the wrong layer, but this solved the specific issue I am seeing, and it keeps other tests from failing.

Unfortunately I am unable to get the benchmark tests running locally, with or without Docker. Both cases are blocked on – I assume – a lack of version pinning:

```shell
$ docker build -t jsonparser .

Sending build context to Docker daemon  832.5kB
Step 1/10 : FROM golang:1.6
 ---> 63330314bb46
Step 2/10 : RUN go get github.com/Jeffail/gabs
 ---> Running in 097509d47196
# github.com/Jeffail/gabs
src/github.com/Jeffail/gabs/gabs.go:486: e.SetEscapeHTML undefined (type *json.Encoder has no field or method SetEscapeHTML)
src/github.com/Jeffail/gabs/gabs.go:493: e.SetIndent undefined (type *json.Encoder has no field or method SetIndent)
src/github.com/Jeffail/gabs/gabs.go:504: encoder.SetEscapeHTML undefined (type *json.Encoder has no field or method SetEscapeHTML)
```

```
go test -test.benchmem -bench JsonParser ./benchmark/ -benchtime 5s -v

# github.com/buger/jsonparser/benchmark
benchmark/benchmark_codecgen.go:70:6: r.EncodeArrayStart undefined (type codec.genHelperEncDriver has no field or method EncodeArrayStart)
benchmark/benchmark_codecgen.go:78:6: r.EncodeMapStart undefined (type codec.genHelperEncDriver has no field or method EncodeMapStart)
benchmark/benchmark_codecgen.go:82:6: z.EncSendContainerState undefined (type codec.genHelperEncoder has no field or method EncSendContainerState)
benchmark/benchmark_codecgen.go:90:6: z.EncSendContainerState undefined (type codec.genHelperEncoder has no field or method EncSendContainerState)
benchmark/benchmark_codecgen.go:92:6: z.EncSendContainerState undefined (type codec.genHelperEncoder has no field or method EncSendContainerState)
benchmark/benchmark_codecgen.go:101:6: z.EncSendContainerState undefined (type codec.genHelperEncoder has no field or method EncSendContainerState)
benchmark/benchmark_codecgen.go:109:6: z.EncSendContainerState undefined (type codec.genHelperEncoder has no field or method EncSendContainerState)
benchmark/benchmark_codecgen.go:111:6: z.EncSendContainerState undefined (type codec.genHelperEncoder has no field or method EncSendContainerState)
benchmark/benchmark_codecgen.go:120:6: z.EncSendContainerState undefined (type codec.genHelperEncoder has no field or method EncSendContainerState)
benchmark/benchmark_codecgen.go:128:6: z.EncSendContainerState undefined (type codec.genHelperEncoder has no field or method EncSendContainerState)
benchmark/benchmark_codecgen.go:128:6: too many errors
FAIL	github.com/buger/jsonparser/benchmark [build failed]
```