### PR TITLE
Arrayeach early termination

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM golang:1.6
+FROM golang:1.7
 
 RUN go get github.com/Jeffail/gabs
 RUN go get github.com/bitly/go-simplejson
 RUN go get github.com/pquerna/ffjson
 RUN go get github.com/antonholmquist/jason
 RUN go get github.com/mreiferson/go-ujson
+RUN go get github.com/a8m/djson
 RUN go get -tags=unsafe -u github.com/ugorji/go/codec
 RUN go get github.com/mailru/easyjson
 

--- a/README.md
+++ b/README.md
@@ -152,9 +152,9 @@ If key data type do not match, it will return error.
 
 ### **`ArrayEach`**
 ```go
-func ArrayEach(data []byte, cb func(value []byte, dataType jsonparser.ValueType, offset int, err error), keys ...string)
+func ArrayEach(data []byte, cb func(value []byte, dataType jsonparser.ValueType, offset int, err *error), keys ...string)
 ```
-Needed for iterating arrays, accepts a callback function with the same return arguments as `Get`.
+Used for iterating arrays, accepts a callback function with the same return arguments as `Get`, except for error. If error is set from within callback, ArrayEach() terminates immediately, returning the same error.
 
 ### **`ObjectEach`**
 ```go

--- a/benchmark/benchmark_large_payload_test.go
+++ b/benchmark/benchmark_large_payload_test.go
@@ -23,12 +23,12 @@ import (
 */
 func BenchmarkJsonParserLarge(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		jsonparser.ArrayEach(largeFixture, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+		jsonparser.ArrayEach(largeFixture, func(value []byte, dataType jsonparser.ValueType, offset int, err *error) {
 			jsonparser.Get(value, "username")
 			nothing()
 		}, "users")
 
-		jsonparser.ArrayEach(largeFixture, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+		jsonparser.ArrayEach(largeFixture, func(value []byte, dataType jsonparser.ValueType, offset int, err *error) {
 			jsonparser.GetInt(value, "id")
 			jsonparser.Get(value, "slug")
 			nothing()

--- a/benchmark/benchmark_medium_payload_test.go
+++ b/benchmark/benchmark_medium_payload_test.go
@@ -31,7 +31,7 @@ func BenchmarkJsonParserMedium(b *testing.B) {
 		jsonparser.GetInt(mediumFixture, "person", "github", "followers")
 		jsonparser.Get(mediumFixture, "company")
 
-		jsonparser.ArrayEach(mediumFixture, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+		jsonparser.ArrayEach(mediumFixture, func(value []byte, dataType jsonparser.ValueType, offset int, err *error) {
 			jsonparser.Get(value, "url")
 			nothing()
 		}, "person", "gravatar", "avatars")
@@ -69,7 +69,7 @@ func BenchmarkJsonParserEachKeyManualMedium(b *testing.B) {
 			case 2:
 			// jsonparser.ParseString(value)
 			case 3:
-				jsonparser.ArrayEach(value, func(avalue []byte, dataType jsonparser.ValueType, offset int, err error) {
+				jsonparser.ArrayEach(value, func(avalue []byte, dataType jsonparser.ValueType, offset int, err *error) {
 					jsonparser.Get(avalue, "url")
 				})
 			}
@@ -105,7 +105,7 @@ func BenchmarkJsonParserEachKeyStructMedium(b *testing.B) {
 				json.Unmarshal(value, &data.Company) // we don't have a JSON -> map[string]interface{} function yet, so use standard encoding/json here
 			case 3:
 				var avatars []*CBAvatar
-				jsonparser.ArrayEach(value, func(avalue []byte, dataType jsonparser.ValueType, offset int, err error) {
+				jsonparser.ArrayEach(value, func(avalue []byte, dataType jsonparser.ValueType, offset int, err *error) {
 					url, _ := jsonparser.ParseString(avalue)
 					avatars = append(avatars, &CBAvatar{Url: url})
 				})
@@ -141,7 +141,7 @@ func BenchmarkJsonParserObjectEachStructMedium(b *testing.B) {
 				missing--
 			case bytes.Equal(k, gravatarKey):
 				var avatars []*CBAvatar
-				jsonparser.ArrayEach(v, func(avalue []byte, dataType jsonparser.ValueType, offset int, err error) {
+				jsonparser.ArrayEach(v, func(avalue []byte, dataType jsonparser.ValueType, offset int, err *error) {
 					url, _ := jsonparser.ParseString(avalue)
 					avatars = append(avatars, &CBAvatar{Url: url})
 				}, "avatars")


### PR DESCRIPTION
**Description**: What this PR does
Added ability to terminate ArrayEach() from within its callback, by setting error to some value.
Previous implementation didn't make much sense, since error was always nil.

**Benchmark before change**:
Benchmark is currently broken, but this fix should not change benchmark times in any way. Might fix benchmark later.

**Benchmark after change**:


For running benchmarks use:
```
go test -test.benchmem -bench JsonParser ./benchmark/ -benchtime 5s -v
# OR
make bench (runs inside docker)
```