### PR TITLE
Minor fixes to panics on certain errors, with complementary unit test…

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -242,6 +242,10 @@ func searchKeys(data []byte, keys ...string) int {
 
 			// if string is a key, and key level match
 			if data[i] == ':' && keyLevel == level-1 {
+				if level < 1 {
+					return -1
+				}
+
 				key := data[keyBegin:keyEnd]
 
 				// for unescape: if there are no escape sequences, this is cheap; if there are, it is a
@@ -439,9 +443,11 @@ func EachKey(data []byte, cb func(int, []byte, ValueType, error), paths ...[]str
 					}
 				}
 
-				switch data[i] {
-				case '{', '}', '[', '"':
-					i--
+				if i < ln {
+					switch data[i] {
+					case '{', '}', '[', '"':
+						i--
+					}
 				}
 			} else {
 				i--

--- a/parser_error_test.go
+++ b/parser_error_test.go
@@ -1,0 +1,40 @@
+package jsonparser
+
+import (
+	"fmt"
+	"testing"
+)
+
+var testPaths = [][]string{
+	[]string{"test"},
+	[]string{"these"},
+	[]string{"keys"},
+	[]string{"please"},
+}
+
+func testIter(data []byte) (err error) {
+	EachKey(data, func(idx int, value []byte, vt ValueType, iterErr error) {
+		if iterErr != nil {
+			err = fmt.Errorf("Error parsing json: %s", iterErr.Error())
+		}
+	}, testPaths...)
+	return err
+}
+
+func TestPanickingErrors(t *testing.T) {
+	if err := testIter([]byte(`{"test":`)); err == nil {
+		t.Error("Expected error...")
+	}
+
+	if err := testIter([]byte(`{"test":0}some":[{"these":[{"keys":"some"}]}]}some"}]}],"please":"some"}`)); err == nil {
+		t.Error("Expected error...")
+	}
+
+	if _, _, _, err := Get([]byte(`{"test":`), "test"); err == nil {
+		t.Error("Expected error...")
+	}
+
+	if _, _, _, err := Get([]byte(`{"some":0}some":[{"some":[{"some":"some"}]}]}some"}]}],"some":"some"}`), "x"); err == nil {
+		t.Error("Expected error...")
+	}
+}


### PR DESCRIPTION
… (unit test can be deleted).

**Description**:
Addresses https://github.com/buger/jsonparser/issues/127 and https://github.com/buger/jsonparser/issues/121. Fixes some index out of range panics.

**Benchmark before change**:
**Benchmark after change**:
Basically the exact same, the change is very minor.

For running benchmarks use:
```
go test -test.benchmem -bench JsonParser ./benchmark/ -benchtime 5s -v
# OR
make bench (runs inside docker)
```