### PR TITLE
Implemented overflow detection in the current parseInt implementation.

### DIFF
--- a/bytes.go
+++ b/bytes.go
@@ -1,9 +1,16 @@
 package jsonparser
 
-// About 3x faster then strconv.ParseInt because does not check for range error and support only base 10, which is enough for JSON
-func parseInt(bytes []byte) (v int64, ok bool) {
+import (
+	bio "bytes"
+)
+
+// minInt64 '-9223372036854775808' is the smallest representable number in int64
+const minInt64 = `9223372036854775808`
+
+// About 2x faster then strconv.ParseInt because it only supports base 10, which is enough for JSON
+func parseInt(bytes []byte) (v int64, ok bool, overflow bool) {
 	if len(bytes) == 0 {
-		return 0, false
+		return 0, false, false
 	}
 
 	var neg bool = false
@@ -12,17 +19,29 @@ func parseInt(bytes []byte) (v int64, ok bool) {
 		bytes = bytes[1:]
 	}
 
+	var b int64 = 0
 	for _, c := range bytes {
 		if c >= '0' && c <= '9' {
-			v = (10 * v) + int64(c-'0')
+			b = (10 * v) + int64(c-'0')
 		} else {
-			return 0, false
+			return 0, false, false
 		}
+		if overflow = (b < v); overflow {
+			break
+		}
+		v = b
+	}
+
+	if overflow {
+		if neg && bio.Equal(bytes, []byte(minInt64)) {
+			return b, true, false
+		}
+		return 0, false, true
 	}
 
 	if neg {
-		return -v, true
+		return -v, true, false
 	} else {
-		return v, true
+		return v, true, false
 	}
 }

--- a/bytes_test.go
+++ b/bytes_test.go
@@ -7,9 +7,10 @@ import (
 )
 
 type ParseIntTest struct {
-	in    string
-	out   int64
-	isErr bool
+	in         string
+	out        int64
+	isErr      bool
+	isOverflow bool
 }
 
 var parseIntTests = []ParseIntTest{
@@ -34,18 +35,37 @@ var parseIntTests = []ParseIntTest{
 		out: -12345,
 	},
 	{
-		in:  "9223372036854775807",
+		in:  "9223372036854775807", // = math.MaxInt64
 		out: 9223372036854775807,
 	},
 	{
-		in:  "-9223372036854775808",
+		in:  "-9223372036854775808", // = math.MinInt64
 		out: -9223372036854775808,
 	},
 	{
-		in:  "18446744073709551616", // = 2^64; integer overflow is not detected
-		out: 0,
+		in:         "-92233720368547758081",
+		out:        0,
+		isErr:      true,
+		isOverflow: true,
 	},
-
+	{
+		in:         "18446744073709551616", // = 2^64
+		out:        0,
+		isErr:      true,
+		isOverflow: true,
+	},
+	{
+		in:         "9223372036854775808", // = math.MaxInt64 - 1
+		out:        0,
+		isErr:      true,
+		isOverflow: true,
+	},
+	{
+		in:         "-9223372036854775809", // = math.MaxInt64 - 1
+		out:        0,
+		isErr:      true,
+		isOverflow: true,
+	},
 	{
 		in:    "",
 		isErr: true,
@@ -70,7 +90,10 @@ var parseIntTests = []ParseIntTest{
 
 func TestBytesParseInt(t *testing.T) {
 	for _, test := range parseIntTests {
-		out, ok := parseInt([]byte(test.in))
+		out, ok, overflow := parseInt([]byte(test.in))
+		if overflow != test.isOverflow {
+			t.Errorf("Test '%s' error return did not overflow expectation (obtained %t, expected %t)", test.in, overflow, test.isOverflow)
+		}
 		if ok != !test.isErr {
 			t.Errorf("Test '%s' error return did not match expectation (obtained %t, expected %t)", test.in, !ok, test.isErr)
 		} else if ok && out != test.out {
@@ -91,5 +114,39 @@ func BenchmarkParseIntUnsafeSlower(b *testing.B) {
 	bytes := []byte("123")
 	for i := 0; i < b.N; i++ {
 		strconv.ParseInt(*(*string)(unsafe.Pointer(&bytes)), 10, 64)
+	}
+}
+
+// Old implementation that did not check for overflows.
+func BenchmarkParseIntOverflows(b *testing.B) {
+	bytes := []byte("123")
+	for i := 0; i < b.N; i++ {
+		parseIntOverflows(bytes)
+	}
+}
+
+func parseIntOverflows(bytes []byte) (v int64, ok bool) {
+	if len(bytes) == 0 {
+		return 0, false
+	}
+
+	var neg bool = false
+	if bytes[0] == '-' {
+		neg = true
+		bytes = bytes[1:]
+	}
+
+	for _, c := range bytes {
+		if c >= '0' && c <= '9' {
+			v = (10 * v) + int64(c-'0')
+		} else {
+			return 0, false
+		}
+	}
+
+	if neg {
+		return -v, true
+	} else {
+		return v, true
 	}
 }

--- a/parser.go
+++ b/parser.go
@@ -17,6 +17,7 @@ var (
 	MalformedArrayError        = errors.New("Value is array, but can't find closing ']' symbol")
 	MalformedObjectError       = errors.New("Value looks like object, but can't find closing '}' symbol")
 	MalformedValueError        = errors.New("Value looks like Number/Boolean/None, but can't find its end: ',' or '}' symbol")
+	OverflowIntegerError       = errors.New("Value is number, but overflowed while parsing")
 	MalformedStringEscapeError = errors.New("Encountered an invalid escape sequence in a string")
 )
 
@@ -1177,7 +1178,10 @@ func ParseFloat(b []byte) (float64, error) {
 
 // ParseInt parses a Number ValueType into a Go int64
 func ParseInt(b []byte) (int64, error) {
-	if v, ok := parseInt(b); !ok {
+	if v, ok, overflow := parseInt(b); !ok {
+		if overflow {
+			return 0, OverflowIntegerError
+		}
 		return 0, MalformedValueError
 	} else {
 		return v, nil

--- a/parser_test.go
+++ b/parser_test.go
@@ -734,7 +734,6 @@ var getTests = []GetTest{
 		isFound: true,
 		data:    "c",
 	},
-
 	// Array index paths
 	{
 		desc:    "last key in path is index",
@@ -813,6 +812,18 @@ var getIntTests = []GetTest{
 		path:    []string{"c"},
 		isFound: true,
 		data:    int64(1),
+	},
+	{ // Issue #138: overflow detection
+		desc:  `Fails because of overflow`,
+		json:  `{"p":9223372036854775808}`,
+		path:  []string{"p"},
+		isErr: true,
+	},
+	{ // Issue #138: overflow detection
+		desc:  `Fails because of underflow`,
+		json:  `{"p":-9223372036854775809}`,
+		path:  []string{"p"},
+		isErr: true,
 	},
 }
 


### PR DESCRIPTION
**Description**: What this PR does
Fixes Issue #138 - Adds int64 overflow check in the current `parseInt` implementation.

I used the benchmarks in `bytes_test` to check performance:
```
 go test -test.benchmem -bench ParseInt ./ -benchtime 5s -run ^A$ -v
goos: darwin
goarch: amd64
pkg: github.com/jstroem/jsonparser
BenchmarkParseInt-8               	1000000000	         7.93 ns/op	       0 B/op	       0 allocs/op
BenchmarkParseIntUnsafeSlower-8   	500000000	        14.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkParseIntOverflows-8      	2000000000	         5.96 ns/op	       0 B/op	       0 allocs/op
```
Note that `BenchmarkParseIntOverflows` is the old implementation. This shows that the fix costs `~2ns/op`.

**Benchmark before change**:
```
goos: darwin
goarch: amd64
pkg: github.com/jstroem/jsonparser/benchmark
BenchmarkJsonParserLarge-8                    	  200000	     55469 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserMedium-8                   	 1000000	      8912 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserDeleteMedium-8             	 1000000	      7331 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-8      	 1000000	      5181 ns/op	     112 B/op	       2 allocs/op
BenchmarkJsonParserEachKeyStructMedium-8      	 1000000	      5782 ns/op	     672 B/op	      12 allocs/op
BenchmarkJsonParserObjectEachStructMedium-8   	 1000000	      8676 ns/op	     624 B/op	      11 allocs/op
BenchmarkJsonParserSmall-8                    	10000000	       831 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-8       	10000000	       618 ns/op	      80 B/op	       2 allocs/op
BenchmarkJsonParserEachKeyStructSmall-8       	10000000	       706 ns/op	     144 B/op	       4 allocs/op
BenchmarkJsonParserObjectEachStructSmall-8    	10000000	       626 ns/op	     128 B/op	       3 allocs/op
BenchmarkJsonParserSetSmall-8                 	10000000	      1146 ns/op	     816 B/op	       5 allocs/op
BenchmarkJsonParserDelSmall-8                 	 5000000	      1379 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/jstroem/jsonparser/benchmark	99.531s
``` 

**Benchmark after change**:
```
goos: darwin
goarch: amd64
pkg: github.com/jstroem/jsonparser/benchmark
BenchmarkJsonParserLarge-8                    	  200000	     56137 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserMedium-8                   	 1000000	      8997 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserDeleteMedium-8             	 1000000	      7398 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-8      	 1000000	      5180 ns/op	     112 B/op	       2 allocs/op
BenchmarkJsonParserEachKeyStructMedium-8      	 1000000	      5810 ns/op	     672 B/op	      12 allocs/op
BenchmarkJsonParserObjectEachStructMedium-8   	 1000000	      8891 ns/op	     624 B/op	      11 allocs/op
BenchmarkJsonParserSmall-8                    	10000000	       878 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-8       	10000000	       665 ns/op	      80 B/op	       2 allocs/op
BenchmarkJsonParserEachKeyStructSmall-8       	10000000	       739 ns/op	     144 B/op	       4 allocs/op
BenchmarkJsonParserObjectEachStructSmall-8    	10000000	       648 ns/op	     128 B/op	       3 allocs/op
BenchmarkJsonParserSetSmall-8                 	10000000	      1200 ns/op	     816 B/op	       5 allocs/op
BenchmarkJsonParserDelSmall-8                 	 5000000	      1597 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/jstroem/jsonparser/benchmark	103.480s
```