### PR TITLE
Fixing the issue of wrong get value

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -644,6 +644,12 @@ var getTests = []GetTest{
 		isFound: true,
 		data:    `4`,
 	},
+	{ // Issue #148
+		desc:    `missing key in different key same level`,
+		json:    `{"s":"s","ic":2,"r":{"o":"invalid"}}`,
+		path:    []string{"ic", "o"},
+		isFound: false,
+	},
 
 	// Error/invalid tests
 	{


### PR DESCRIPTION
**Description**: What this PR does
This Pr fixes the bug of **Get**  function where nested values return the wrong result of some other parent key [because of the same nestinglevel].
**Benchmark before change**:
```
goos: darwin
goarch: amd64
pkg: github.com/soniabhishek/jsonparser/benchmark
BenchmarkJsonParserLarge-4                        100000             60877 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserMedium-4                      1000000              9819 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserDeleteMedium-4                1000000             10166 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-4         1000000              6054 ns/op             112 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructMedium-4         1000000              6788 ns/op             672 B/op         12 allocs/op
BenchmarkJsonParserObjectEachStructMedium-4      1000000              9934 ns/op             624 B/op         11 allocs/op
BenchmarkJsonParserSmall-4                      10000000              1017 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-4         10000000               781 ns/op              80 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructSmall-4         10000000               898 ns/op             144 B/op          4 allocs/op
BenchmarkJsonParserObjectEachStructSmall-4      10000000               793 ns/op             128 B/op          3 allocs/op
BenchmarkJsonParserSetSmall-4                    5000000              1438 ns/op             816 B/op          5 allocs/op
BenchmarkJsonParserDelSmall-4                    5000000              1818 ns/op               0 B/op          0 allocs/op
PASS
ok      github.com/soniabhishek/jsonparser/benchmark    108.018s

```
**Benchmark after change**:

```
goos: darwin
goarch: amd64
pkg: github.com/soniabhishek/jsonparser/benchmark
BenchmarkJsonParserLarge-4                        100000             58374 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserMedium-4                      1000000              9417 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserDeleteMedium-4                 500000             10217 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-4         1000000              6024 ns/op             112 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructMedium-4         1000000              6854 ns/op             672 B/op         12 allocs/op
BenchmarkJsonParserObjectEachStructMedium-4      1000000              9783 ns/op             624 B/op         11 allocs/op
BenchmarkJsonParserSmall-4                      10000000              1001 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-4         10000000               789 ns/op              80 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructSmall-4         10000000               903 ns/op             144 B/op          4 allocs/op
BenchmarkJsonParserObjectEachStructSmall-4      10000000               800 ns/op             128 B/op          3 allocs/op
BenchmarkJsonParserSetSmall-4                    5000000              1451 ns/op             816 B/op          5 allocs/op
BenchmarkJsonParserDelSmall-4                    5000000              3665 ns/op               0 B/op          0 allocs/op
PASS
ok      github.com/soniabhishek/jsonparser/benchmark    111.569s
```
For running benchmarks use:
```
go test -test.benchmem -bench JsonParser ./benchmark/ -benchtime 5s -v
# OR
make bench (runs inside docker)
```