### PR TITLE
Prevent infinite looping in GetString on certain malformed strings

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -333,6 +333,8 @@ func searchKeys(data []byte, keys ...string) int {
 					i += arraySkip - 1
 				}
 			}
+		case ':': // If encountered, JSON data is malformed
+			return -1
 		}
 
 		i++

--- a/parser_test.go
+++ b/parser_test.go
@@ -886,6 +886,20 @@ var getStringTests = []GetTest{
 		isFound: true,
 		data:    "value\b\f\n\r\tvalue", // value is unescaped since this is GetString()
 	},
+	{ // This test checks we avoid an infinite loop for certain malformed JSON. We don't check for all malformed JSON as it would reduce performance.
+		desc: `malformed with double quotes`,
+		json: `{"a"":1}`,
+		path: []string{"a"},
+		isFound: false,
+		data: ``,
+	},
+	{ // More malformed JSON testing, to be sure we avoid an infinite loop.
+		desc: `malformed with double quotes, and path does not exist`,
+		json: `{"z":123,"y":{"x":7,"w":0},"v":{"u":"t","s":"r","q":0,"p":1558051800},"a":"b","c":"2016-11-02T20:10:11Z","d":"e","f":"g","h":{"i":"j""},"k":{"l":"m"}}`,
+		path: []string{"o"},
+		isFound: false,
+		data: ``,
+	},
 }
 
 var getBoolTests = []GetTest{


### PR DESCRIPTION
**Description**: This PR is to address the open issue: https://github.com/buger/jsonparser/issues/164

**Benchmark before change**:

goos: darwin
goarch: amd64
pkg: github.com/buger/jsonparser/benchmark
BenchmarkJsonParserLarge-8                        200000             49082 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserMedium-8                      1000000              7254 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserDeleteMedium-8                1000000              7638 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-8         1000000              5123 ns/op             112 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructMedium-8         1000000              5726 ns/op             544 B/op         12 allocs/op
BenchmarkJsonParserObjectEachStructMedium-8      1000000              7774 ns/op             496 B/op         11 allocs/op
BenchmarkJsonParserSmall-8                      10000000               766 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-8         10000000               616 ns/op              80 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructSmall-8         10000000              1192 ns/op             192 B/op          8 allocs/op
BenchmarkJsonParserObjectEachStructSmall-8      10000000               784 ns/op             176 B/op          7 allocs/op
BenchmarkJsonParserSetSmall-8                   10000000              1105 ns/op             768 B/op          4 allocs/op
BenchmarkJsonParserDelSmall-8                    5000000              1388 ns/op               0 B/op          0 allocs/op
PASS
ok      github.com/buger/jsonparser/benchmark   101.571s


**Benchmark after change**:

goos: darwin
goarch: amd64
pkg: github.com/buger/jsonparser/benchmark
BenchmarkJsonParserLarge-8                        200000             47197 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserMedium-8                      1000000              7353 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserDeleteMedium-8                1000000              7470 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-8         1000000              5169 ns/op             112 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructMedium-8         1000000              5568 ns/op             544 B/op         12 allocs/op
BenchmarkJsonParserObjectEachStructMedium-8      1000000              7740 ns/op             496 B/op         11 allocs/op
BenchmarkJsonParserSmall-8                      10000000               750 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-8         20000000               621 ns/op              80 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructSmall-8         10000000               835 ns/op             192 B/op          8 allocs/op
BenchmarkJsonParserObjectEachStructSmall-8      10000000               721 ns/op             176 B/op          7 allocs/op
BenchmarkJsonParserSetSmall-8                   10000000              1100 ns/op             768 B/op          4 allocs/op
BenchmarkJsonParserDelSmall-8                    5000000              1565 ns/op               0 B/op          0 allocs/op
PASS
ok      github.com/buger/jsonparser/benchmark   104.016s


For running benchmarks use:
```
go test -test.benchmem -bench JsonParser ./benchmark/ -benchtime 5s -v
# OR
make bench (runs inside docker)
```