### PR TITLE
Attempt to fix #174, EachKey missing nested extractions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/buger/jsonparser
+
+go 1.13

--- a/parser.go
+++ b/parser.go
@@ -436,12 +436,8 @@ func EachKey(data []byte, cb func(int, []byte, ValueType, error), paths ...[]str
 						pathsMatched++
 						pathFlags |= bitwiseFlags[pi+1]
 
-						v, dt, of, e := Get(data[i:])
+						v, dt, _, e := Get(data[i:])
 						cb(pi, v, dt, e)
-
-						if of != -1 {
-							i += of
-						}
 
 						if pathsMatched == len(paths) {
 							break

--- a/parser_test.go
+++ b/parser_test.go
@@ -887,18 +887,18 @@ var getStringTests = []GetTest{
 		data:    "value\b\f\n\r\tvalue", // value is unescaped since this is GetString()
 	},
 	{ // This test checks we avoid an infinite loop for certain malformed JSON. We don't check for all malformed JSON as it would reduce performance.
-		desc: `malformed with double quotes`,
-		json: `{"a"":1}`,
-		path: []string{"a"},
+		desc:    `malformed with double quotes`,
+		json:    `{"a"":1}`,
+		path:    []string{"a"},
 		isFound: false,
-		data: ``,
+		data:    ``,
 	},
 	{ // More malformed JSON testing, to be sure we avoid an infinite loop.
-		desc: `malformed with double quotes, and path does not exist`,
-		json: `{"z":123,"y":{"x":7,"w":0},"v":{"u":"t","s":"r","q":0,"p":1558051800},"a":"b","c":"2016-11-02T20:10:11Z","d":"e","f":"g","h":{"i":"j""},"k":{"l":"m"}}`,
-		path: []string{"o"},
+		desc:    `malformed with double quotes, and path does not exist`,
+		json:    `{"z":123,"y":{"x":7,"w":0},"v":{"u":"t","s":"r","q":0,"p":1558051800},"a":"b","c":"2016-11-02T20:10:11Z","d":"e","f":"g","h":{"i":"j""},"k":{"l":"m"}}`,
+		path:    []string{"o"},
 		isFound: false,
-		data: ``,
+		data:    ``,
 	},
 }
 
@@ -1466,6 +1466,7 @@ func TestEachKey(t *testing.T) {
 		{"arr", "[1]", "b"},
 		{"arrInt", "[3]"},
 		{"arrInt", "[5]"}, // Should not find last key
+		{"nested"},
 	}
 
 	keysFound := 0
@@ -1506,13 +1507,19 @@ func TestEachKey(t *testing.T) {
 			if string(value) != "4" {
 				t.Error("Should find 8 key", string(value))
 			}
+		case 8:
+			t.Errorf("Found key #8 that should not be found")
+		case 9:
+			if string(value) != `{"a":"test", "b":2, "nested3":{"a":"test3","b":4}, "c": "unknown"}` {
+				t.Error("Should find 9 key", string(value))
+			}
 		default:
-			t.Errorf("Should found only 8 keys")
+			t.Errorf("Should find only 9 keys, got %v key", idx)
 		}
 	}, paths...)
 
-	if keysFound != 8 {
-		t.Errorf("Should find 8 keys: %d", keysFound)
+	if keysFound != 9 {
+		t.Errorf("Should find 9 keys: %d", keysFound)
 	}
 }
 


### PR DESCRIPTION
 If you are trying to extract "foo" and "foo.bar" from '{"foo": {"bar": 1}}' with EachKey, the parser would find the "foo" key, extract the contents ('{"bar": 1}'), and then *add the offset* of
that extraction to the current index. This means it would never find the "bar" key. This change simply eliminates the adding of the offset.

This appears to fix #174 and includes a test for it.

**Description**: What this PR does

**Benchmark before change**:
Benchmarks are broken.