### PR TITLE
fix issue 188

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -98,9 +98,15 @@ func findKeyStart(data []byte, key string) (int, error) {
 			}
 
 		case '[':
-			i = blockEnd(data[i:], data[i], ']') + i
+			end := blockEnd(data[i:], data[i], ']')
+			if end != -1 {
+				i = i + end
+			}
 		case '{':
-			i = blockEnd(data[i:], data[i], '}') + i
+			end := blockEnd(data[i:], data[i], '}')
+			if end != -1 {
+				i = i + end
+			}
 		}
 		i++
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -185,6 +185,18 @@ var deleteTests = []DeleteTest{
 		path: []string{"b"},
 		data: `{"a": "1" , "c": 3}`,
 	},
+	{
+		desc: "Issue #188: infinite loop in Delete",
+		json: `^_ï¿½^C^A^@[`,
+		path: []string{""},
+		data: `^_ï¿½^C^A^@[`,
+	},
+	{
+		desc: "Issue #188: infinite loop in Delete",
+		json: `^_ï¿½^C^A^@{`,
+		path: []string{""},
+		data: `^_ï¿½^C^A^@{`,
+	},
 }
 
 var setTests = []SetTest{


### PR DESCRIPTION
**Description**: This pr fix issue #188. If `findKeyStart` meets a `[` or `{`, it should not add i with `blockEnd`’s return value directly because it may return -1 if it did not find the close symbol