### PR TITLE
fix issue #165

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -388,7 +388,6 @@ func EachKey(data []byte, cb func(int, []byte, ValueType, error), paths ...[]str
 		}
 	}
 
-	var stackbuf [unescapeStackBufSize]byte // stack-allocated array for allocation-free unescaping of small strings
 	pathsBuf := make([]string, maxPath)
 
 	for i < ln {
@@ -420,6 +419,7 @@ func EachKey(data []byte, cb func(int, []byte, ValueType, error), paths ...[]str
 				// for unescape: if there are no escape sequences, this is cheap; if there are, it is a
 				// bit more expensive, but causes no allocations unless len(key) > unescapeStackBufSize
 				var keyUnesc []byte
+				var stackbuf [unescapeStackBufSize]byte
 				if !keyEscaped {
 					keyUnesc = key
 				} else if ku, err := Unescape(key, stackbuf[:]); err != nil {

--- a/parser_test.go
+++ b/parser_test.go
@@ -1579,7 +1579,33 @@ func TestObjectEach(t *testing.T) {
 	}
 }
 
-var testJson = []byte(`{"name": "Name", "order": "Order", "sum": 100, "len": 12, "isPaid": true, "nested": {"a":"test", "b":2, "nested3":{"a":"test3","b":4}, "c": "unknown"}, "nested2": {"a":"test2", "b":3}, "arr": [{"a":"zxc", "b": 1}, {"a":"123", "b":2}], "arrInt": [1,2,3,4], "intPtr": 10}`)
+var testJson = []byte(`{
+	"name": "Name", 
+	"order": "Order", 
+	"sum": 100, 
+	"len": 12, 
+	"isPaid": true, 
+	"nested": {"a":"test", "b":2, "nested3":{"a":"test3","b":4}, "c": "unknown"}, 
+	"nested2": {
+		"a":"test2", 
+		"b":3
+	}, 
+	"arr": [
+		{
+			"a":"zxc", 
+			"b": 1
+		}, 
+		{
+			"a":"123", 
+			"b":2
+		}
+	], 
+	"arrInt": [1,2,3,4], 
+	"intPtr": 10, 
+	"a\n":{
+		"b\n":99
+	}
+}`)
 
 func TestEachKey(t *testing.T) {
 	paths := [][]string{
@@ -1594,6 +1620,7 @@ func TestEachKey(t *testing.T) {
 		{"arrInt", "[5]"}, // Should not find last key
 		{"nested"},
 		{"arr", "["}, // issue#177 Invalid arguments
+		{"a\n", "b\n"}, // issue#165
 	}
 
 	keysFound := 0
@@ -1642,13 +1669,17 @@ func TestEachKey(t *testing.T) {
 			}
 		case 10:
 			t.Errorf("Found key #10 that should not be found")
+		case 11:
+			if string(value) != "99" {
+				t.Error("Should find 10 key", string(value))
+			}
 		default:
-			t.Errorf("Should find only 9 keys, got %v key", idx)
+			t.Errorf("Should find only 10 keys, got %v key", idx)
 		}
 	}, paths...)
 
-	if keysFound != 9 {
-		t.Errorf("Should find 9 keys: %d", keysFound)
+	if keysFound != 10 {
+		t.Errorf("Should find 10 keys: %d", keysFound)
 	}
 }
 


### PR DESCRIPTION
**Description**: This PR fix issue #165. Since the use of `bytesToString` hack, `stackbuf` can't be reused to save the unescape result of the key. It will make the `pathsBuf`'s string element point to the same memory area if the path has more than one key which need to be unescaped. And that will make the `EachKey` can't not locate the key correctly. 