### PR TITLE
improve Set performance as #issue107 descripes

### DIFF
--- a/benchmark/benchmark_set_test.go
+++ b/benchmark/benchmark_set_test.go
@@ -1,0 +1,20 @@
+package benchmark
+
+import (
+	"github.com/buger/jsonparser"
+	"strconv"
+	"testing"
+)
+
+func BenchmarkSetLarge(b *testing.B) {
+	b.ReportAllocs()
+
+	keyPath := make([]string, 20000)
+	for i := range keyPath {
+		keyPath[i] = "keyPath" + strconv.Itoa(i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = jsonparser.Set(largeFixture, largeFixture, keyPath...)
+	}
+}


### PR DESCRIPTION
**Description**: 
This pr improve the `Set` performance as #107 mentions.With large key path and set value, it brings an about 20% improvement.

Before:
```
goos: linux
goarch: amd64
pkg: github.com/buger/jsonparser
BenchmarkSetLarge-4   	    1000	   1002014 ns/op	 1611185 B/op	      15 allocs/op
```
After:
```
goos: linux
goarch: amd64
pkg: github.com/buger/jsonparser
BenchmarkSetLarge-4   	    1278	    791653 ns/op	 1232897 B/op	       4 allocs/op
```