### PR TITLE
Fix infinite loop in Get

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -294,6 +294,9 @@ func searchKeys(data []byte, keys ...string) int {
 			// can move to the end of this block
 			if !lastMatched {
 				end := blockEnd(data[i:], '{', '}')
+				if end == -1 {
+					return -1
+				}
 				i += end - 1
 			} else {
 				level++

--- a/parser_test.go
+++ b/parser_test.go
@@ -861,9 +861,15 @@ var getTests = []GetTest{
 	},
 	{
 		// Issue #178: Crash in searchKeys
-		desc: `invalid json`,
-		json: `{{{"":`,
-		path: []string{"a", "b"},
+		desc:    `invalid json`,
+		json:    `{{{"":`,
+		path:    []string{"a", "b"},
+		isFound: false,
+	},
+	{
+		desc:    `opening brace instead of closing and without key`,
+		json:    `{"a":1{`,
+		path:    []string{"b"},
 		isFound: false,
 	},
 }


### PR DESCRIPTION
**Description**: Fixed an infinite loop in `Get` (more precisely in `searchKeys`), when there is an opening brace instead of a closing and no key.

**Benchmark before change**:
```
goos: darwin
goarch: amd64
pkg: benchmarks
BenchmarkJsonParserLarge-12                               126344             45841 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserMedium-12                              721712              7623 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserDeleteMedium-12                        681780              8168 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-12                 919440              5554 ns/op             112 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructMedium-12                 863677              6060 ns/op             560 B/op         12 allocs/op
BenchmarkJsonParserObjectEachStructMedium-12              692349              7698 ns/op             512 B/op         11 allocs/op
BenchmarkJsonParserSmall-12                              8271370               707 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-12                 9597409               628 ns/op              80 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructSmall-12                 7657132               781 ns/op             192 B/op          8 allocs/op
BenchmarkJsonParserObjectEachStructSmall-12              9485541               624 ns/op             176 B/op          7 allocs/op
BenchmarkJsonParserSetSmall-12                           6084676               974 ns/op             768 B/op          4 allocs/op
BenchmarkJsonParserDelSmall-12                           4632402              1282 ns/op               0 B/op          0 allocs/op
PASS
ok      benchmarks      74.548s
```

**Benchmark after change**:
```
goos: darwin
goarch: amd64
pkg: benchmarks
BenchmarkJsonParserLarge-12                               126489             45862 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserMedium-12                              664927              7624 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserDeleteMedium-12                        674773              8172 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualMedium-12                1084482              5545 ns/op             112 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructMedium-12                 878842              6063 ns/op             560 B/op         12 allocs/op
BenchmarkJsonParserObjectEachStructMedium-12              686784              7721 ns/op             512 B/op         11 allocs/op
BenchmarkJsonParserSmall-12                              7804009               712 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-12                 9694530               614 ns/op              80 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructSmall-12                 7668559               780 ns/op             192 B/op          8 allocs/op
BenchmarkJsonParserObjectEachStructSmall-12              9493740               622 ns/op             176 B/op          7 allocs/op
BenchmarkJsonParserSetSmall-12                           6069998               975 ns/op             768 B/op          4 allocs/op
BenchmarkJsonParserDelSmall-12                           4665757              1279 ns/op               0 B/op          0 allocs/op
PASS
ok      benchmarks      79.686s
```