### PR TITLE
Fix possible memory confusion in unsafe slice cast

### DIFF
--- a/bytes_unsafe.go
+++ b/bytes_unsafe.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strconv"
 	"unsafe"
+	"runtime"
 )
 
 //
@@ -32,11 +33,12 @@ func bytesToString(b *[]byte) string {
 }
 
 func StringToBytes(s string) []byte {
+	b := make([]byte, 0, 0)
+	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	bh := reflect.SliceHeader{
-		Data: sh.Data,
-		Len:  sh.Len,
-		Cap:  sh.Len,
-	}
-	return *(*[]byte)(unsafe.Pointer(&bh))
+	bh.Data = sh.Data
+	bh.Cap = sh.Len
+	bh.Len = sh.Len
+	runtime.KeepAlive(s)
+	return b
 }


### PR DESCRIPTION
**Description**:

I found an incorrect cast from `string` to `[]byte` in `bytes_unsafe.go`. The problem is that when `reflect.SliceHeader` is created as a composite literal (instead of deriving it from an actual slice by cast), then the Go garbage collector will not treat its `Data` field as a reference. If the GC runs just between creating the `SliceHeader` and casting it into the final, real `[]byte` slice, then the underlying data might have been collected already, effectively making the returned `[]byte` slice a dangling pointer.

This has a low probability to occur, but projects that import this library might still use it in a code path that gets executed a lot, thus increasing the probability to happen. Depending on the memory layout at the time of the GC run, this could potentially create an information leak vulnerability.

This PR changes the function to create the `reflect.SliceHeader` from an actual slice by first instantiating the return value.

**Benchmark before change**: n/a

**Benchmark after change**: n/a

For running benchmarks use:
```
go test -test.benchmem -bench JsonParser ./benchmark/ -benchtime 5s -v
# OR
make bench (runs inside docker)
```

Both failed for me, therefore I skipped running the benchmark, sorry about that!