### PR TITLE
Added oss-fuzz build script

### DIFF
--- a/oss-fuzz-build.sh
+++ b/oss-fuzz-build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -eu
+
+function compile_fuzzer {
+  path=$1
+  function=$2
+  fuzzer=$3
+
+  go-fuzz -func $function -o $fuzzer.a $path
+
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
+}
+
+compile_fuzzer github.com/buger/jsonparser FuzzParseString fuzz


### PR DESCRIPTION
**Description**: This PR moves over the build script of the fuzzers from oss-fuzz to jsonparsers own repo. This is recommended by Google to allow maintainers to easier update the build of the fuzzers in case of adding new fuzzers or the build breaking.
When merged in, I will update the integration at oss-fuzz to run the build script from here.

**Benchmark**: This PR does not change the performance of the core functionality.