### PR TITLE
EachKey: do not allocate array if there is no need

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -422,13 +422,15 @@ func EachKey(data []byte, cb func(int, []byte, ValueType, error), paths ...[]str
 				// for unescape: if there are no escape sequences, this is cheap; if there are, it is a
 				// bit more expensive, but causes no allocations unless len(key) > unescapeStackBufSize
 				var keyUnesc []byte
-				var stackbuf [unescapeStackBufSize]byte
 				if !keyEscaped {
 					keyUnesc = key
-				} else if ku, err := Unescape(key, stackbuf[:]); err != nil {
-					return -1
 				} else {
-					keyUnesc = ku
+					var stackbuf [unescapeStackBufSize]byte
+					if ku, err := Unescape(key, stackbuf[:]); err != nil {
+						return -1
+					} else {
+						keyUnesc = ku
+					}
 				}
 
 				if maxPath >= level {


### PR DESCRIPTION
**Description**: What this PR does
This PR reduces unnecessary array allocations in `EachKey` function.
In our application, we heavily use `EachKey` to traverse moderately big JSON objects and our benchmarks showed that this would reduce allocation up to 55%:
```
name                       old time/op    new time/op    delta
ParseRequest-8    84.7µs ± 2%    76.7µs ± 2%   -9.47%  (p=0.000 n=9+10)

name                       old alloc/op   new alloc/op   delta
ParseRequest-8    20.7kB ± 0%     9.3kB ± 0%  -55.15%  (p=0.000 n=10+10)

name                       old allocs/op  new allocs/op  delta
ParseRequest-8       370 ± 0%       192 ± 0%  -48.11%  (p=0.000 n=10+10)
```

**Benchmark before change**:
```BenchmarkJsonParserLarge
BenchmarkJsonParserLarge-8                        127772             46406 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserMedium
BenchmarkJsonParserMedium-8                       783925              7386 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserDeleteMedium
BenchmarkJsonParserDeleteMedium-8                 488871             13074 ns/op           12352 B/op          7 allocs/op
BenchmarkJsonParserEachKeyManualMedium
BenchmarkJsonParserEachKeyManualMedium-8          718426              8417 ns/op            4592 B/op         72 allocs/op
BenchmarkJsonParserEachKeyStructMedium
BenchmarkJsonParserEachKeyStructMedium-8          669814              9104 ns/op            5040 B/op         82 allocs/op
BenchmarkJsonParserObjectEachStructMedium
BenchmarkJsonParserObjectEachStructMedium-8       772330              7506 ns/op             448 B/op         10 allocs/op
BenchmarkJsonParserSmall
BenchmarkJsonParserSmall-8                       7662243               770 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualSmall
BenchmarkJsonParserEachKeyManualSmall-8          6154617               998 ns/op             528 B/op          9 allocs/op
BenchmarkJsonParserEachKeyStructSmall
BenchmarkJsonParserEachKeyStructSmall-8          4874719              1209 ns/op             640 B/op         15 allocs/op
BenchmarkJsonParserObjectEachStructSmall
BenchmarkJsonParserObjectEachStructSmall-8       8326891               680 ns/op             112 B/op          6 allocs/op
BenchmarkJsonParserSetSmall
BenchmarkJsonParserSetSmall-8                    4711480              1222 ns/op             768 B/op          4 allocs/op
BenchmarkJsonParserDelSmall
BenchmarkJsonParserDelSmall-8                    2959894              2020 ns/op             976 B/op          8 allocs/op

```
**Benchmark after change**:
```
BenchmarkJsonParserLarge
BenchmarkJsonParserLarge-8                        130033             47934 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserMedium
BenchmarkJsonParserMedium-8                       773694              7482 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserDeleteMedium
BenchmarkJsonParserDeleteMedium-8                 484461             12878 ns/op           12352 B/op          7 allocs/op
BenchmarkJsonParserEachKeyManualMedium
BenchmarkJsonParserEachKeyManualMedium-8         1000000              5130 ns/op              48 B/op          1 allocs/op
BenchmarkJsonParserEachKeyStructMedium
BenchmarkJsonParserEachKeyStructMedium-8         1000000              5760 ns/op             496 B/op         11 allocs/op
BenchmarkJsonParserObjectEachStructMedium
BenchmarkJsonParserObjectEachStructMedium-8       712172              7493 ns/op             448 B/op         10 allocs/op
BenchmarkJsonParserSmall
BenchmarkJsonParserSmall-8                       7567230               764 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualSmall
BenchmarkJsonParserEachKeyManualSmall-8          8969059               654 ns/op              16 B/op          1 allocs/op
BenchmarkJsonParserEachKeyStructSmall
BenchmarkJsonParserEachKeyStructSmall-8          6836643               836 ns/op             128 B/op          7 allocs/op
BenchmarkJsonParserObjectEachStructSmall
BenchmarkJsonParserObjectEachStructSmall-8       8643297               686 ns/op             112 B/op          6 allocs/op
BenchmarkJsonParserSetSmall
BenchmarkJsonParserSetSmall-8                    4850605              1240 ns/op             768 B/op          4 allocs/op
BenchmarkJsonParserDelSmall
BenchmarkJsonParserDelSmall-8                    2977360              1976 ns/op             976 B/op          8 allocs/op

```