### PR TITLE
Array and guess

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -986,7 +986,7 @@ func ArrayEach(data []byte, cb func(value []byte, dataType ValueType, offset int
 		}
 
 		if e != nil {
-			break
+			return offset + o - len(v), e
 		}
 
 		offset += o

--- a/parser.go
+++ b/parser.go
@@ -982,7 +982,7 @@ func ArrayEach(data []byte, cb func(value []byte, dataType ValueType, offset int
 		}
 
 		if t != NotExist {
-			cb(v, t, offset+o-len(v), e)
+			e = cb(v, t, offset+o-len(v), e)
 		}
 
 		if e != nil {

--- a/parser.go
+++ b/parser.go
@@ -557,7 +557,15 @@ func EachKey(data []byte, cb func(int, []byte, ValueType, error), paths ...[]str
 	return -1
 }
 
-func GuessValueType(data []byte, offset int) (ValueType, error) {
+// GuessValueType : returns the type of the next JSON piece in data stream
+// Does not ensure that the whole data is a valid JSON
+func GuessValueType(data []byte) (ValueType, error) {
+
+	offset := nextToken(data)
+	if offset == -1 {
+		return NotExist, MalformedJsonError
+	}
+
 	_, dataType, _, err := getType(data, offset)
 	return dataType, err
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -12,16 +12,18 @@ import (
 var activeTest = ""
 
 func toArray(data []byte) (result [][]byte) {
-	ArrayEach(data, func(value []byte, dataType ValueType, offset int, err error) {
+	ArrayEach(data, func(value []byte, dataType ValueType, offset int, err error) error {
 		result = append(result, value)
+		return nil
 	})
 
 	return
 }
 
 func toStringArray(data []byte) (result []string) {
-	ArrayEach(data, func(value []byte, dataType ValueType, offset int, err error) {
+	ArrayEach(data, func(value []byte, dataType ValueType, offset int, err error) error {
 		result = append(result, string(value))
+		return nil
 	})
 
 	return
@@ -1363,7 +1365,7 @@ func TestArrayEach(t *testing.T) {
 	mock := []byte(`{"a": { "b":[{"x": 1} ,{"x":2},{ "x":3}, {"x":4} ]}}`)
 	count := 0
 
-	ArrayEach(mock, func(value []byte, dataType ValueType, offset int, err error) {
+	ArrayEach(mock, func(value []byte, dataType ValueType, offset int, err error) error {
 		count++
 
 		switch count {
@@ -1386,14 +1388,18 @@ func TestArrayEach(t *testing.T) {
 		default:
 			t.Errorf("Should process only 4 items")
 		}
+		return nil
 	}, "a", "b")
 }
 
 func TestArrayEachWithWhiteSpace(t *testing.T) {
 	//Issue #159
 	count := 0
-	funcError := func([]byte, ValueType, int, error) { t.Errorf("Run func not allow") }
-	funcSuccess := func(value []byte, dataType ValueType, index int, err error) {
+	funcError := func([]byte, ValueType, int, error) error {
+		t.Errorf("Run func not allow")
+		return nil
+	}
+	funcSuccess := func(value []byte, dataType ValueType, index int, err error) error {
 		count++
 
 		switch count {
@@ -1412,17 +1418,18 @@ func TestArrayEachWithWhiteSpace(t *testing.T) {
 		default:
 			t.Errorf("Should process only 3 items")
 		}
+		return nil
 	}
 
 	type args struct {
 		data []byte
-		cb   func(value []byte, dataType ValueType, offset int, err error)
+		cb   func(value []byte, dataType ValueType, offset int, err error) error
 		keys []string
 	}
 	tests := []struct {
-		name       string
-		args       args
-		wantErr    bool
+		name    string
+		args    args
+		wantErr bool
 	}{
 		{"Array with white space", args{[]byte(`    ["AAA", "BBB", "CCC"]`), funcSuccess, []string{}}, false},
 		{"Array with only one character after white space", args{[]byte(`    1`), funcError, []string{}}, true},
@@ -1440,11 +1447,14 @@ func TestArrayEachWithWhiteSpace(t *testing.T) {
 }
 
 func TestArrayEachEmpty(t *testing.T) {
-	funcError := func([]byte, ValueType, int, error) { t.Errorf("Run func not allow") }
+	funcError := func([]byte, ValueType, int, error) error {
+		t.Errorf("Run func not allow")
+		return nil
+	}
 
 	type args struct {
 		data []byte
-		cb   func(value []byte, dataType ValueType, offset int, err error)
+		cb   func(value []byte, dataType ValueType, offset int, err error) error
 		keys []string
 	}
 	tests := []struct {
@@ -1675,7 +1685,7 @@ func TestEachKey(t *testing.T) {
 		{"arrInt", "[3]"},
 		{"arrInt", "[5]"}, // Should not find last key
 		{"nested"},
-		{"arr", "["}, // issue#177 Invalid arguments
+		{"arr", "["},   // issue#177 Invalid arguments
 		{"a\n", "b\n"}, // issue#165
 	}
 


### PR DESCRIPTION
**Description**: 
- Adding a simple public API allowing to guess what would be the result if we parse the data provided
- Adding a way to stop array processing (like the one existing for objects) so that we fail early if required

**Benchmark before change**:
BenchmarkJsonParserLarge
BenchmarkJsonParserLarge-2                         91435             57791 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserMedium
BenchmarkJsonParserMedium-2                       638395              9380 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserDeleteMedium
BenchmarkJsonParserDeleteMedium-2                 578287             10228 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualMedium
BenchmarkJsonParserEachKeyManualMedium-2          928076              6298 ns/op             112 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructMedium
BenchmarkJsonParserEachKeyStructMedium-2          830934              7886 ns/op             560 B/op         12 allocs/op
BenchmarkJsonParserObjectEachStructMedium
BenchmarkJsonParserObjectEachStructMedium-2       572341              9921 ns/op             512 B/op         11 allocs/op
BenchmarkJsonParserSmall
BenchmarkJsonParserSmall-2                       6185480               915 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualSmall
BenchmarkJsonParserEachKeyManualSmall-2          8068620               746 ns/op              80 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructSmall
BenchmarkJsonParserEachKeyStructSmall-2          5681413              1073 ns/op             184 B/op          7 allocs/op
BenchmarkJsonParserObjectEachStructSmall
BenchmarkJsonParserObjectEachStructSmall-2       6723812               891 ns/op             168 B/op          6 allocs/op
BenchmarkJsonParserSetSmall
BenchmarkJsonParserSetSmall-2                    4120005              1439 ns/op             768 B/op          4 allocs/op
BenchmarkJsonParserDelSmall
BenchmarkJsonParserDelSmall-2                    3427260              1767 ns/op               0 B/op          0 allocs/op


**Benchmark after change**:
BenchmarkJsonParserLarge
BenchmarkJsonParserLarge-2                         99598             57717 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserMedium
BenchmarkJsonParserMedium-2                       553732              9533 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserDeleteMedium
BenchmarkJsonParserDeleteMedium-2                 576543             10439 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualMedium
BenchmarkJsonParserEachKeyManualMedium-2          944497              6367 ns/op             112 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructMedium
BenchmarkJsonParserEachKeyStructMedium-2          803428              7304 ns/op             560 B/op         12 allocs/op
BenchmarkJsonParserObjectEachStructMedium
BenchmarkJsonParserObjectEachStructMedium-2       566092             10477 ns/op             512 B/op         11 allocs/op
BenchmarkJsonParserSmall
BenchmarkJsonParserSmall-2                       6631508               908 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualSmall
BenchmarkJsonParserEachKeyManualSmall-2          8210907               753 ns/op              80 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructSmall
BenchmarkJsonParserEachKeyStructSmall-2          5331390              1098 ns/op             184 B/op          7 allocs/op
BenchmarkJsonParserObjectEachStructSmall
BenchmarkJsonParserObjectEachStructSmall-2       6622808               900 ns/op             168 B/op          6 allocs/op
BenchmarkJsonParserSetSmall
BenchmarkJsonParserSetSmall-2                    3944966              1473 ns/op             768 B/op          4 allocs/op
BenchmarkJsonParserDelSmall
BenchmarkJsonParserDelSmall-2                    3349132              1796 ns/op               0 B/op          0 allocs/op

