### PR TITLE
Eachkey fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
 module github.com/buger/jsonparser
 
 go 1.13
+

--- a/parser.go
+++ b/parser.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"math"
 	"strconv"
 )
 
@@ -354,14 +353,6 @@ func searchKeys(data []byte, keys ...string) int {
 	}
 
 	return -1
-}
-
-var bitwiseFlags []int64
-
-func init() {
-	for i := 0; i < 63; i++ {
-		bitwiseFlags = append(bitwiseFlags, int64(math.Pow(2, float64(i))))
-	}
 }
 
 func sameTree(p1, p2 []string) bool {

--- a/parser_error_test.go
+++ b/parser_error_test.go
@@ -2,6 +2,7 @@ package jsonparser
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -37,4 +38,143 @@ func TestPanickingErrors(t *testing.T) {
 	if _, _, _, err := Get([]byte(`{"some":0}some":[{"some":[{"some":"some"}]}]}some"}]}],"some":"some"}`), "x"); err == nil {
 		t.Error("Expected error...")
 	}
+}
+
+// check having a very deep key depth
+func TestKeyDepth(t *testing.T) {
+	var sb strings.Builder
+	var keys []string
+	//build data
+	sb.WriteString("{")
+	for i := 0; i < 128; i++ {
+		fmt.Fprintf(&sb, `"key%d": %dx,`, i, i)
+		keys = append(keys, fmt.Sprintf("key%d", i))
+	}
+	sb.WriteString("}")
+
+	data := []byte(sb.String())
+	EachKey(data, func(offset int, value []byte, dt ValueType, err error) {
+		return
+	}, keys)
+}
+
+// check having a bunch of keys in a call to EachKey
+func TestKeyCount(t *testing.T) {
+	var sb strings.Builder
+	var keys [][]string
+	//build data
+	sb.WriteString("{")
+	for i := 0; i < 128; i++ {
+		fmt.Fprintf(&sb, `"key%d":"%d"`, i, i)
+		if i < 127 {
+			sb.WriteString(",")
+		}
+		keys = append(keys, []string{fmt.Sprintf("key%d", i)})
+	}
+	sb.WriteString("}")
+
+	data := []byte(sb.String())
+	EachKey(data, func(offset int, value []byte, dt ValueType, err error) {
+		return
+	}, keys...)
+}
+
+// try pulling lots of keys out of a big array
+func TestKeyDepthArray(t *testing.T) {
+	var sb strings.Builder
+	var keys []string
+	//build data
+	sb.WriteString("[")
+	for i := 0; i < 128; i++ {
+		fmt.Fprintf(&sb, `{"key": %d},`, i)
+		keys = append(keys, fmt.Sprintf("[%d].key", i))
+	}
+	sb.WriteString("]")
+
+	data := []byte(sb.String())
+	EachKey(data, func(offset int, value []byte, dt ValueType, err error) {
+		return
+	}, keys)
+}
+
+// check having a bunch of keys
+func TestKeyCountArray(t *testing.T) {
+	var sb strings.Builder
+	var keys [][]string
+	//build data
+	sb.WriteString("[")
+	for i := 0; i < 128; i++ {
+		fmt.Fprintf(&sb, `{"key":"%d"}`, i)
+		if i < 127 {
+			sb.WriteString(",")
+		}
+		keys = append(keys, []string{fmt.Sprintf("[%d].key", i)})
+	}
+	sb.WriteString("]")
+
+	data := []byte(sb.String())
+	EachKey(data, func(offset int, value []byte, dt ValueType, err error) {
+		return
+	}, keys...)
+}
+
+// check having a bunch of keys in a super deep array
+func TestEachKeyArray(t *testing.T) {
+	var sb strings.Builder
+	var keys [][]string
+	//build data
+	sb.WriteString(`[`)
+	for i := 0; i < 127; i++ {
+		fmt.Fprintf(&sb, `%d`, i)
+		if i < 127 {
+			sb.WriteString(",")
+		}
+		if i < 32 {
+			keys = append(keys, []string{fmt.Sprintf("[%d]", 128+i)})
+		}
+	}
+	sb.WriteString(`]`)
+
+	data := []byte(sb.String())
+	EachKey(data, func(offset int, value []byte, dt ValueType, err error) {
+		return
+	}, keys...)
+}
+
+func TestLargeArray(t *testing.T) {
+	var sb strings.Builder
+	//build data
+	sb.WriteString(`[`)
+	for i := 0; i < 127; i++ {
+		fmt.Fprintf(&sb, `%d`, i)
+		if i < 127 {
+			sb.WriteString(",")
+		}
+	}
+	sb.WriteString(`]`)
+	keys := [][]string{[]string{`[1]`}}
+
+	data := []byte(sb.String())
+	EachKey(data, func(offset int, value []byte, dt ValueType, err error) {
+		return
+	}, keys...)
+}
+
+func TestArrayOutOfBounds(t *testing.T) {
+	var sb strings.Builder
+	//build data
+	sb.WriteString(`[`)
+	for i := 0; i < 61; i++ {
+		fmt.Fprintf(&sb, `%d`, i)
+		if i < 61 {
+			sb.WriteString(",")
+		}
+	}
+	sb.WriteString(`]`)
+	keys := [][]string{[]string{`[128]`}}
+
+	data := []byte(sb.String())
+	EachKey(data, func(offset int, value []byte, dt ValueType, err error) {
+		return
+	}, keys...)
 }


### PR DESCRIPTION
**Description**: What this PR does
Per #56, EachKey cannot handle a variety of cases where there are more than 64 keys, or 64 elements in an array we're extracting. This fixes that.

Note that the PR template's command for running benchmarks (`go test -test.benchmem -bench JsonParser ./benchmark/ -benchtime 5s -v`) doesn't work, so I instead added a replace directive in the benchmark/ directory's go.mod to point at my checked-out repository, then ran `go test -bench .` against the master branch, then against my branch.

**Benchmark before change**:
```
goos: linux
goarch: amd64
pkg: benchmarks
BenchmarkDeleteSmall-16                         	 1890744	       622 ns/op	     256 B/op	       3 allocs/op
BenchmarkDeleteNested-16                        	 2652386	       445 ns/op	     160 B/op	       2 allocs/op
BenchmarkDeleteLarge-16                         	   27751	     42538 ns/op	   32976 B/op	       4 allocs/op
BenchmarkJsonParserLarge-16                     	   22432	     52544 ns/op
BenchmarkEncodingJsonStructLarge-16             	    2826	    375274 ns/op
BenchmarkEncodingJsonInterfaceLarge-16          	    1760	    652624 ns/op
BenchmarkFFJsonLarge-16                         	    7461	    161655 ns/op
BenchmarkEasyJsonLarge-16                       	   14215	     86164 ns/op
BenchmarkDjsonLarge-16                          	    2882	    394393 ns/op
BenchmarkJsonParserMedium-16                    	  142406	      7983 ns/op
BenchmarkJsonParserDeleteMedium-16              	   66177	     18689 ns/op
BenchmarkJsonParserEachKeyManualMedium-16       	   95619	     12839 ns/op
BenchmarkJsonParserEachKeyStructMedium-16       	   86356	     14061 ns/op
BenchmarkJsonParserObjectEachStructMedium-16    	  135129	      8601 ns/op
BenchmarkEncodingJsonStructMedium-16            	   41817	     29282 ns/op
BenchmarkEncodingJsonInterfaceMedium-16         	   28939	     41163 ns/op
BenchmarkGabsMedium-16                          	   28653	     44121 ns/op
BenchmarkGoSimpleJsonMedium-16                  	   24699	     48544 ns/op
BenchmarkFFJsonMedium-16                        	  111526	     10672 ns/op
BenchmarkJasonMedium-16                         	   22724	     51735 ns/op
BenchmarkUjsonMedium-16                         	   35376	     33149 ns/op
BenchmarkDjsonMedium-16                         	   50370	     22166 ns/op
BenchmarkUgirjiMedium-16                        	   23074	     48843 ns/op
BenchmarkEasyJsonMedium-16                      	  196198	      6132 ns/op
BenchmarkJsonParserSmall-16                     	 1514832	       800 ns/op
BenchmarkJsonParserEachKeyManualSmall-16        	  731673	      1487 ns/op
BenchmarkJsonParserEachKeyStructSmall-16        	  866870	      1819 ns/op
BenchmarkJsonParserObjectEachStructSmall-16     	 1551387	       773 ns/op
BenchmarkJsonParserSetSmall-16                  	  647980	      1738 ns/op
BenchmarkJsonParserDelSmall-16                  	  495890	      2819 ns/op
BenchmarkEncodingJsonStructSmall-16             	  275402	      4455 ns/op
BenchmarkEncodingJsonInterfaceSmall-16          	  222865	      5003 ns/op
BenchmarkGabsSmall-16                           	  229048	      5471 ns/op
BenchmarkGoSimplejsonSmall-16                   	  197372	      5861 ns/op
BenchmarkGoSimplejsonSetSmall-16                	  204316	      5694 ns/op
BenchmarkFFJsonSmall-16                         	  406246	      2480 ns/op
BenchmarkJasonSmall-16                          	   75861	     15973 ns/op
BenchmarkUjsonSmall-16                          	  305860	      3912 ns/op
BenchmarkDjsonSmall-16                          	  433152	      2723 ns/op
BenchmarkUgirjiSmall-16                         	  259401	      4575 ns/op
BenchmarkEasyJsonSmall-16                       	 1151031	      1021 ns/op
PASS
ok  	benchmarks	59.982s
```

**Benchmark after change**:
```
goos: linux
goarch: amd64
pkg: benchmarks
BenchmarkDeleteSmall-16                         	 1908750	       628 ns/op	     256 B/op	       3 allocs/op
BenchmarkDeleteNested-16                        	 2525209	       463 ns/op	     160 B/op	       2 allocs/op
BenchmarkDeleteLarge-16                         	   26755	     44093 ns/op	   32976 B/op	       4 allocs/op
BenchmarkJsonParserLarge-16                     	   21904	     52531 ns/op
BenchmarkEncodingJsonStructLarge-16             	    2890	    376510 ns/op
BenchmarkEncodingJsonInterfaceLarge-16          	    1797	    643310 ns/op
BenchmarkFFJsonLarge-16                         	    7437	    160658 ns/op
BenchmarkEasyJsonLarge-16                       	   14097	     86033 ns/op
BenchmarkDjsonLarge-16                          	    3388	    398946 ns/op
BenchmarkJsonParserMedium-16                    	  143050	      7907 ns/op
BenchmarkJsonParserDeleteMedium-16              	   61576	     18450 ns/op
BenchmarkJsonParserEachKeyManualMedium-16       	   91599	     12510 ns/op
BenchmarkJsonParserEachKeyStructMedium-16       	   94472	     13368 ns/op
BenchmarkJsonParserObjectEachStructMedium-16    	  130995	      8881 ns/op
BenchmarkEncodingJsonStructMedium-16            	   41547	     29998 ns/op
BenchmarkEncodingJsonInterfaceMedium-16         	   28642	     41842 ns/op
BenchmarkGabsMedium-16                          	   29258	     44583 ns/op
BenchmarkGoSimpleJsonMedium-16                  	   24452	     48066 ns/op
BenchmarkFFJsonMedium-16                        	  110073	     10582 ns/op
BenchmarkJasonMedium-16                         	   22927	     51748 ns/op
BenchmarkUjsonMedium-16                         	   36816	     31486 ns/op
BenchmarkDjsonMedium-16                         	   54476	     22146 ns/op
BenchmarkUgirjiMedium-16                        	   24409	     51023 ns/op
BenchmarkEasyJsonMedium-16                      	  194780	      6136 ns/op
BenchmarkJsonParserSmall-16                     	 1530714	       781 ns/op
BenchmarkJsonParserEachKeyManualSmall-16        	  954934	      1446 ns/op
BenchmarkJsonParserEachKeyStructSmall-16        	  602458	      1699 ns/op
BenchmarkJsonParserObjectEachStructSmall-16     	 1564392	       799 ns/op
BenchmarkJsonParserSetSmall-16                  	  677536	      1778 ns/op
BenchmarkJsonParserDelSmall-16                  	  393672	      2814 ns/op
BenchmarkEncodingJsonStructSmall-16             	  253527	      4668 ns/op
BenchmarkEncodingJsonInterfaceSmall-16          	  218199	      5077 ns/op
BenchmarkGabsSmall-16                           	  213379	      5588 ns/op
BenchmarkGoSimplejsonSmall-16                   	  203370	      5843 ns/op
BenchmarkGoSimplejsonSetSmall-16                	  188271	      5668 ns/op
BenchmarkFFJsonSmall-16                         	  414210	      2536 ns/op
BenchmarkJasonSmall-16                          	   72268	     15271 ns/op
BenchmarkUjsonSmall-16                          	  297141	      3795 ns/op
BenchmarkDjsonSmall-16                          	  508090	      2659 ns/op
BenchmarkUgirjiSmall-16                         	  267682	      4705 ns/op
BenchmarkEasyJsonSmall-16                       	 1154594	      1052 ns/op
PASS
ok  	benchmarks	59.805s
```