### PR TITLE
Cve 2020 35381

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -308,7 +308,11 @@ func searchKeys(data []byte, keys ...string) int {
 		case '[':
 			// If we want to get array element by index
 			if keyLevel == level && keys[level][0] == '[' {
-				aIdx, err := strconv.Atoi(keys[level][1 : len(keys[level])-1])
+				var keyLen = len(keys[level])
+				if keyLen < 3 || keys[level][0] != '[' || keys[level][keyLen-1] != ']' {
+					return -1
+				}
+				aIdx, err := strconv.Atoi(keys[level][1 : keyLen-1])
 				if err != nil {
 					return -1
 				}

--- a/parser_test.go
+++ b/parser_test.go
@@ -988,6 +988,18 @@ var getStringTests = []GetTest{
 		path:  []string{"c"},
 		isErr: true,
 	},
+	{
+		desc:  `empty array index`,
+		json:  `[""]`,
+		path:  []string{"[]"},
+		isFound: false,
+	},
+	{
+		desc:  `malformed array index`,
+		json:  `[""]`,
+		path:  []string{"["},
+		isFound: false,
+	},
 }
 
 var getUnsafeStringTests = []GetTest{


### PR DESCRIPTION
Attempt to fix #219 and introduce a test.  The only error that can easily be returned in this case is `KeyPathNotFoundError`, which is reasonable if you squint (a malformed key can not be found).

Note I'm far from fluent in golang so this should be reviewed with some care :smile: