### PR TITLE
Updated travis to build for 1.13 to 1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ arch:
     - amd64
     - ppc64le
 go:
-    - 1.7.x
-    - 1.8.x
-    - 1.9.x
-    - 1.10.x
-    - 1.11.x
+    - 1.13.x
+    - 1.14.x
+    - 1.15.x
 script: go test -v ./.


### PR DESCRIPTION
**Description**: Changed versions to be checked by TravisCI. This should fix #224.

**Benchmark before change**:

```none
goos: linux
goarch: amd64
pkg: benchmarks
BenchmarkJsonParserLarge
BenchmarkJsonParserLarge-2                        123830             56023 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserMedium
BenchmarkJsonParserMedium-2                       617190              9450 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserDeleteMedium
BenchmarkJsonParserDeleteMedium-2                 599527              9954 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualMedium
BenchmarkJsonParserEachKeyManualMedium-2          990694              6832 ns/op             112 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructMedium
BenchmarkJsonParserEachKeyStructMedium-2          672381              7868 ns/op             560 B/op         12 allocs/op
BenchmarkJsonParserObjectEachStructMedium
BenchmarkJsonParserObjectEachStructMedium-2       488502             10899 ns/op             512 B/op         11 allocs/op
BenchmarkJsonParserSmall
BenchmarkJsonParserSmall-2                       5806060              1026 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualSmall
BenchmarkJsonParserEachKeyManualSmall-2          7169103               792 ns/op              80 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructSmall
BenchmarkJsonParserEachKeyStructSmall-2          5692335              1166 ns/op             184 B/op          7 allocs/op
BenchmarkJsonParserObjectEachStructSmall
BenchmarkJsonParserObjectEachStructSmall-2       5675881              1007 ns/op             168 B/op          6 allocs/op
BenchmarkJsonParserSetSmall
BenchmarkJsonParserSetSmall-2                    2858661              1960 ns/op             768 B/op          4 allocs/op
BenchmarkJsonParserDelSmall
BenchmarkJsonParserDelSmall-2                    2703586              1960 ns/op               0 B/op          0 allocs/op
PASS
ok      benchmarks      88.682s
```

**Benchmark after change**:

```none
goos: linux
goarch: amd64
pkg: benchmarks
BenchmarkJsonParserLarge
BenchmarkJsonParserLarge-2                        116294             48680 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserMedium
BenchmarkJsonParserMedium-2                       679485              9280 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserDeleteMedium
BenchmarkJsonParserDeleteMedium-2                 475312             11617 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualMedium
BenchmarkJsonParserEachKeyManualMedium-2          862095              6581 ns/op             112 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructMedium
BenchmarkJsonParserEachKeyStructMedium-2          748077              7466 ns/op             560 B/op         12 allocs/op
BenchmarkJsonParserObjectEachStructMedium
BenchmarkJsonParserObjectEachStructMedium-2       531387             12811 ns/op             512 B/op         11 allocs/op
BenchmarkJsonParserSmall
BenchmarkJsonParserSmall-2                       5425960              1080 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualSmall
BenchmarkJsonParserEachKeyManualSmall-2          7067673               993 ns/op              80 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructSmall
BenchmarkJsonParserEachKeyStructSmall-2          5003574              1298 ns/op             184 B/op          7 allocs/op
BenchmarkJsonParserObjectEachStructSmall
BenchmarkJsonParserObjectEachStructSmall-2       6200142              1095 ns/op             168 B/op          6 allocs/op
BenchmarkJsonParserSetSmall
BenchmarkJsonParserSetSmall-2                    3303882              2400 ns/op             768 B/op          4 allocs/op
BenchmarkJsonParserDelSmall
BenchmarkJsonParserDelSmall-2                    3211975              1729 ns/op               0 B/op          0 allocs/op
PASS
ok      benchmarks      89.444s
```

Note: the commands I used to run the benchmarks are as follows:

```none
cd benchmark
go test -test.benchmem -bench JsonParser . -benchtime 5s -v
```

This adds `go 1.15` (my version of Go) in `benchmark/go.mod` which I decided **not** to commit.