### PR TITLE
fix deletion by key with leading space

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -49,10 +49,10 @@ func findTokenStart(data []byte, token byte) int {
 }
 
 func findKeyStart(data []byte, key string) (int, error) {
-	i := 0
+	i := nextToken(data)
 	ln := len(data)
-	if ln > 0 && (data[0] == '{' || data[0] == '[') {
-		i = 1
+	if ln > 0 && (data[i] == '{' || data[i] == '[') {
+		i += 1
 	}
 	var stackbuf [unescapeStackBufSize]byte // stack-allocated array for allocation-free unescaping of small strings
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -221,6 +221,12 @@ var deleteTests = []DeleteTest{
 		path: []string{""},
 		data: `^_ï¿½^C^A^@{`,
 	},
+	{
+		desc: "Issue #150: leading space",
+		json: `   {"test":"input"}`,
+		path: []string{"test"},
+		data: `   {}`,
+	},
 }
 
 var setTests = []SetTest{
@@ -989,15 +995,15 @@ var getStringTests = []GetTest{
 		isErr: true,
 	},
 	{
-		desc:  `empty array index`,
-		json:  `[""]`,
-		path:  []string{"[]"},
+		desc:    `empty array index`,
+		json:    `[""]`,
+		path:    []string{"[]"},
 		isFound: false,
 	},
 	{
-		desc:  `malformed array index`,
-		json:  `[""]`,
-		path:  []string{"["},
+		desc:    `malformed array index`,
+		json:    `[""]`,
+		path:    []string{"["},
 		isFound: false,
 	},
 }


### PR DESCRIPTION
**Description**: fix issue #150 (in deleting case)

**Benchmark before change**:
```
BenchmarkJsonParserLarge
BenchmarkJsonParserLarge-8                        149128             40492 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserMedium
BenchmarkJsonParserMedium-8                       876039              6657 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserDeleteMedium
BenchmarkJsonParserDeleteMedium-8                 823548              7070 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualMedium
BenchmarkJsonParserEachKeyManualMedium-8         1371667              4380 ns/op             112 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructMedium
BenchmarkJsonParserEachKeyStructMedium-8         1229190              4880 ns/op             560 B/op         12 allocs/op
BenchmarkJsonParserObjectEachStructMedium
BenchmarkJsonParserObjectEachStructMedium-8       862562              6859 ns/op             512 B/op         11 allocs/op
BenchmarkJsonParserSmall
BenchmarkJsonParserSmall-8                       8717104               673 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualSmall
BenchmarkJsonParserEachKeyManualSmall-8         11227440               537 ns/op              80 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructSmall
BenchmarkJsonParserEachKeyStructSmall-8          8229375               724 ns/op             184 B/op          7 allocs/op
BenchmarkJsonParserObjectEachStructSmall
BenchmarkJsonParserObjectEachStructSmall-8       9805533               614 ns/op             168 B/op          6 allocs/op
BenchmarkJsonParserSetSmall
BenchmarkJsonParserSetSmall-8                    6156210               972 ns/op             768 B/op          4 allocs/op
BenchmarkJsonParserDelSmall
BenchmarkJsonParserDelSmall-8                    4657131              1276 ns/op               0 B/op          0 allocs/op
```

**Benchmark after change**:
```
BenchmarkJsonParserLarge
BenchmarkJsonParserLarge-8                        147148             40662 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserMedium
BenchmarkJsonParserMedium-8                       872667              6710 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserDeleteMedium
BenchmarkJsonParserDeleteMedium-8                 823443              7106 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualMedium
BenchmarkJsonParserEachKeyManualMedium-8         1363668              4446 ns/op             112 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructMedium
BenchmarkJsonParserEachKeyStructMedium-8         1215337              4927 ns/op             560 B/op         12 allocs/op
BenchmarkJsonParserObjectEachStructMedium
BenchmarkJsonParserObjectEachStructMedium-8       843268              6930 ns/op             512 B/op         11 allocs/op
BenchmarkJsonParserSmall
BenchmarkJsonParserSmall-8                       8753600               682 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualSmall
BenchmarkJsonParserEachKeyManualSmall-8         11106930               540 ns/op              80 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructSmall
BenchmarkJsonParserEachKeyStructSmall-8          8219354               731 ns/op             184 B/op          7 allocs/op
BenchmarkJsonParserObjectEachStructSmall
BenchmarkJsonParserObjectEachStructSmall-8       9774537               625 ns/op             168 B/op          6 allocs/op
BenchmarkJsonParserSetSmall
BenchmarkJsonParserSetSmall-8                    5996592               984 ns/op             768 B/op          4 allocs/op
BenchmarkJsonParserDelSmall
BenchmarkJsonParserDelSmall-8                    4472648              1365 ns/op               0 B/op          0 allocs/op
```