### PR TITLE
fixing the oss-fuzz issue

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -50,6 +50,9 @@ func findTokenStart(data []byte, token byte) int {
 
 func findKeyStart(data []byte, key string) (int, error) {
 	i := nextToken(data)
+	if i == -1 {
+		return i, KeyPathNotFoundError
+	}
 	ln := len(data)
 	if ln > 0 && (data[i] == '{' || data[i] == '[') {
 		i += 1


### PR DESCRIPTION
**Description**: 
 * fixed oss-fuzz issue related to index out of range error (#226)

**Benchmark before change**:
```
BenchmarkJsonParserLarge
BenchmarkJsonParserLarge-8                        143898             41691 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserMedium
BenchmarkJsonParserMedium-8                       827924              6878 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserDeleteMedium
BenchmarkJsonParserDeleteMedium-8                 735854              7448 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualMedium
BenchmarkJsonParserEachKeyManualMedium-8         1309497              4598 ns/op             112 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructMedium
BenchmarkJsonParserEachKeyStructMedium-8         1000000              5122 ns/op             560 B/op         12 allocs/op
BenchmarkJsonParserObjectEachStructMedium
BenchmarkJsonParserObjectEachStructMedium-8       807538              7187 ns/op             512 B/op         11 allocs/op
BenchmarkJsonParserSmall
BenchmarkJsonParserSmall-8                       8489175               690 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualSmall
BenchmarkJsonParserEachKeyManualSmall-8         10728361               560 ns/op              80 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructSmall
BenchmarkJsonParserEachKeyStructSmall-8          7935544               755 ns/op             184 B/op          7 allocs/op
BenchmarkJsonParserObjectEachStructSmall
BenchmarkJsonParserObjectEachStructSmall-8       9516604               649 ns/op             168 B/op          6 allocs/op
BenchmarkJsonParserSetSmall
BenchmarkJsonParserSetSmall-8                    5906934              1010 ns/op             768 B/op          4 allocs/op
BenchmarkJsonParserDelSmall
BenchmarkJsonParserDelSmall-8                    4318345              1409 ns/op               0 B/op          0 allocs/op
```

**Benchmark after change**:
```
BenchmarkJsonParserLarge
BenchmarkJsonParserLarge-8                        144520             41727 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserMedium
BenchmarkJsonParserMedium-8                       856867              6956 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserDeleteMedium
BenchmarkJsonParserDeleteMedium-8                 797840              7241 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualMedium
BenchmarkJsonParserEachKeyManualMedium-8         1340912              4495 ns/op             112 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructMedium
BenchmarkJsonParserEachKeyStructMedium-8         1000000              5088 ns/op             560 B/op         12 allocs/op
BenchmarkJsonParserObjectEachStructMedium
BenchmarkJsonParserObjectEachStructMedium-8       824574              7521 ns/op             512 B/op         11 allocs/op
BenchmarkJsonParserSmall
BenchmarkJsonParserSmall-8                       8247644               709 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualSmall
BenchmarkJsonParserEachKeyManualSmall-8         10772722               549 ns/op              80 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructSmall
BenchmarkJsonParserEachKeyStructSmall-8          8077488               769 ns/op             184 B/op          7 allocs/op
BenchmarkJsonParserObjectEachStructSmall
BenchmarkJsonParserObjectEachStructSmall-8       9299766               645 ns/op             168 B/op          6 allocs/op
BenchmarkJsonParserSetSmall
BenchmarkJsonParserSetSmall-8                    5936330               993 ns/op             768 B/op          4 allocs/op
BenchmarkJsonParserDelSmall
BenchmarkJsonParserDelSmall-8                    4526785              1314 ns/op               0 B/op          0 allocs/op
```