### PR TITLE
Added bespoke error for null cases

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -18,6 +18,7 @@ var (
 	MalformedValueError        = errors.New("Value looks like Number/Boolean/None, but can't find its end: ',' or '}' symbol")
 	OverflowIntegerError       = errors.New("Value is number, but overflowed while parsing")
 	MalformedStringEscapeError = errors.New("Encountered an invalid escape sequence in a string")
+	NullValueError             = errors.New("Value is null")
 )
 
 // How much stack space to allocate for unescaping JSON strings; if a string longer
@@ -311,7 +312,7 @@ func searchKeys(data []byte, keys ...string) int {
 		case '[':
 			// If we want to get array element by index
 			if keyLevel == level && keys[level][0] == '[' {
-				var keyLen = len(keys[level])
+				keyLen := len(keys[level])
 				if keyLen < 3 || keys[level][0] != '[' || keys[level][keyLen-1] != ']' {
 					return -1
 				}
@@ -322,7 +323,7 @@ func searchKeys(data []byte, keys ...string) int {
 				var curIdx int
 				var valueFound []byte
 				var valueOffset int
-				var curI = i
+				curI := i
 				ArrayEach(data[i:], func(value []byte, dataType ValueType, offset int, err error) {
 					if curIdx == aIdx {
 						valueFound = value
@@ -1191,6 +1192,9 @@ func GetString(data []byte, keys ...string) (val string, err error) {
 	}
 
 	if t != String {
+		if t == Null {
+			return "", NullValueError
+		}
 		return "", fmt.Errorf("Value is not a string: %s", string(v))
 	}
 
@@ -1213,6 +1217,9 @@ func GetFloat(data []byte, keys ...string) (val float64, err error) {
 	}
 
 	if t != Number {
+		if t == Null {
+			return 0, NullValueError
+		}
 		return 0, fmt.Errorf("Value is not a number: %s", string(v))
 	}
 
@@ -1229,6 +1236,9 @@ func GetInt(data []byte, keys ...string) (val int64, err error) {
 	}
 
 	if t != Number {
+		if t == Null {
+			return 0, NullValueError
+		}
 		return 0, fmt.Errorf("Value is not a number: %s", string(v))
 	}
 
@@ -1246,6 +1256,9 @@ func GetBoolean(data []byte, keys ...string) (val bool, err error) {
 	}
 
 	if t != Boolean {
+		if t == Null {
+			return false, NullValueError
+		}
 		return false, fmt.Errorf("Value is not a boolean: %s", string(v))
 	}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -913,6 +913,12 @@ var getIntTests = []GetTest{
 		path:  []string{"c"},
 		isErr: true,
 	},
+	{
+		desc:  `null test`,
+		json:  `{"a": "b", "c": null}`,
+		path:  []string{"c"},
+		isErr: true,
+	},
 }
 
 var getFloatTests = []GetTest{
@@ -933,6 +939,12 @@ var getFloatTests = []GetTest{
 	{
 		desc:  `read non-numeric value as float`,
 		json:  `{"a": "b", "c": "d"}`,
+		path:  []string{"c"},
+		isErr: true,
+	},
+	{
+		desc:  `null test`,
+		json:  `{"a": "b", "c": null}`,
 		path:  []string{"c"},
 		isErr: true,
 	},
@@ -1005,6 +1017,12 @@ var getStringTests = []GetTest{
 		json:    `[""]`,
 		path:    []string{"["},
 		isFound: false,
+	},
+	{
+		desc:  `null test`,
+		json:  `{"c": null}`,
+		path:  []string{"c"},
+		isErr: true,
 	},
 }
 
@@ -1086,6 +1104,13 @@ var getBoolTests = []GetTest{
 		path:    []string{"a"},
 		isFound: true,
 		data:    true,
+	},
+	{
+		desc:    `null test`,
+		json:    `{"a": "b", "c": null}`,
+		path:    []string{"c"},
+		isFound: false,
+		isErr:   true,
 	},
 }
 
@@ -1408,7 +1433,7 @@ func TestArrayEach(t *testing.T) {
 }
 
 func TestArrayEachWithWhiteSpace(t *testing.T) {
-	//Issue #159
+	// Issue #159
 	count := 0
 	funcError := func([]byte, ValueType, int, error) { t.Errorf("Run func not allow") }
 	funcSuccess := func(value []byte, dataType ValueType, index int, err error) {


### PR DESCRIPTION
**Description**: This adds a bespoke null error to the typed Get functions

**Benchmark before change**:
```
BenchmarkJsonParserLarge
BenchmarkJsonParserLarge-4                    	  101186	     59316 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserMedium
BenchmarkJsonParserMedium-4                   	  664688	      9127 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserDeleteMedium
BenchmarkJsonParserDeleteMedium-4             	  584113	     16541 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualMedium
BenchmarkJsonParserEachKeyManualMedium-4      	  697446	      7584 ns/op	     112 B/op	       2 allocs/op
BenchmarkJsonParserEachKeyStructMedium
BenchmarkJsonParserEachKeyStructMedium-4      	  718255	      9049 ns/op	     544 B/op	      12 allocs/op
BenchmarkJsonParserObjectEachStructMedium
BenchmarkJsonParserObjectEachStructMedium-4   	  598053	     14774 ns/op	     496 B/op	      11 allocs/op
BenchmarkJsonParserSmall
BenchmarkJsonParserSmall-4                    	 5438990	      1097 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualSmall
BenchmarkJsonParserEachKeyManualSmall-4       	 8123079	       726.3 ns/op	      80 B/op	       2 allocs/op
BenchmarkJsonParserEachKeyStructSmall
BenchmarkJsonParserEachKeyStructSmall-4       	 5914904	      1101 ns/op	     184 B/op	       7 allocs/op
BenchmarkJsonParserObjectEachStructSmall
BenchmarkJsonParserObjectEachStructSmall-4    	 3735968	      1712 ns/op	     168 B/op	       6 allocs/op
BenchmarkJsonParserSetSmall
BenchmarkJsonParserSetSmall-4                 	 2382969	      3151 ns/op	     768 B/op	       4 allocs/op
BenchmarkJsonParserDelSmall
BenchmarkJsonParserDelSmall-4                 	 1917996	      4370 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	benchmarks	104.655s
```


**Benchmark after change**:
```
BenchmarkJsonParserLarge
BenchmarkJsonParserLarge-4                    	   98062	     63203 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserMedium
BenchmarkJsonParserMedium-4                   	  570456	      9970 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserDeleteMedium
BenchmarkJsonParserDeleteMedium-4             	  603286	     13375 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualMedium
BenchmarkJsonParserEachKeyManualMedium-4      	  780256	      9199 ns/op	     112 B/op	       2 allocs/op
BenchmarkJsonParserEachKeyStructMedium
BenchmarkJsonParserEachKeyStructMedium-4      	  419198	     15755 ns/op	     544 B/op	      12 allocs/op
BenchmarkJsonParserObjectEachStructMedium
BenchmarkJsonParserObjectEachStructMedium-4   	  362432	     16357 ns/op	     496 B/op	      11 allocs/op
BenchmarkJsonParserSmall
BenchmarkJsonParserSmall-4                    	 3645873	      1711 ns/op	       0 B/op	       0 allocs/op
BenchmarkJsonParserEachKeyManualSmall
BenchmarkJsonParserEachKeyManualSmall-4       	 5796182	      1012 ns/op	      80 B/op	       2 allocs/op
BenchmarkJsonParserEachKeyStructSmall
BenchmarkJsonParserEachKeyStructSmall-4       	 5057808	      1171 ns/op	     184 B/op	       7 allocs/op
BenchmarkJsonParserObjectEachStructSmall
BenchmarkJsonParserObjectEachStructSmall-4    	 5825636	      1145 ns/op	     168 B/op	       6 allocs/op
BenchmarkJsonParserSetSmall
BenchmarkJsonParserSetSmall-4                 	 3933043	      2098 ns/op	     768 B/op	       4 allocs/op
BenchmarkJsonParserDelSmall
BenchmarkJsonParserDelSmall-4                 	 2888763	      1989 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	benchmarks	93.459s
```