### PR TITLE
fix EachKey pIdxFlags allocation

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -499,7 +499,12 @@ func EachKey(data []byte, cb func(int, []byte, ValueType, error), paths ...[]str
 		case '[':
 			var ok bool
 			arrIdxFlags := make(map[int]struct{})
-			pIdxFlags := make([]bool, len(paths))
+
+			pIdxFlags := make([]bool, stackArraySize)[:]
+			if len(paths) > cap(pIdxFlags) {
+				pIdxFlags = make([]bool, len(paths))[:]
+			}
+			pIdxFlags = pIdxFlags[0:len(paths)]
 
 			if level < 0 {
 				cb(-1, nil, Unknown, MalformedJsonError)


### PR DESCRIPTION
**Description**: This pr implements patch from #223, which original author never made a PR for. Fixes one allocation in EachKey function caused by allocating pIdxFlags array.

**Benchmark before change**:
```   
BenchmarkJsonParserEachKeyManualMedium
BenchmarkJsonParserEachKeyManualMedium-12         805526              6450 ns/op               8 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructMedium
BenchmarkJsonParserEachKeyStructMedium-12         644608              9243 ns/op             408 B/op         12 allocs/op
```

**Benchmark after change**:
```      
BenchmarkJsonParserEachKeyManualMedium
BenchmarkJsonParserEachKeyManualMedium-12         947583              6521 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyStructMedium
BenchmarkJsonParserEachKeyStructMedium-12         776686              8836 ns/op             400 B/op         10 allocs/op
```