### PR TITLE
fix: bounds check in Delete to prevent index out of range panic

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -752,6 +752,10 @@ func Delete(data []byte, keys ...string) []byte {
 		tokEnd := tokenEnd(data[endOffset:])
 		tokStart := findTokenStart(data[:keyOffset], ","[0])
 
+		if endOffset+tokEnd >= len(data) {
+			return data
+		}
+
 		if data[endOffset+tokEnd] == ","[0] {
 			endOffset += tokEnd + 1
 		} else if data[endOffset+tokEnd] == " "[0] && len(data) > endOffset+tokEnd+1 && data[endOffset+tokEnd+1] == ","[0] {


### PR DESCRIPTION
Fixes #274

## Problem

`Delete` accesses `data[endOffset+tokEnd]` without checking if the index is within bounds. `tokenEnd()` returns `len(data)` when no terminator is found, so `endOffset+tokEnd` can exceed the slice length, causing a panic:

```
panic: runtime error: index out of range [9] with length 9
```

Found by fuzzing.

## Fix

Add a bounds check before accessing `data[endOffset+tokEnd]`:

```go
if endOffset+tokEnd >= len(data) {
    return data
}
```

All existing tests pass.