### PR TITLE
fix: guard Delete against out-of-range endOffset+tokEnd on fuzz input

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -707,12 +707,10 @@ func WriteToBuffer(buffer []byte, str string) int {
 }
 
 /*
-
 Del - Receives existing data structure, path to delete.
 
 Returns:
 `data` - return modified data
-
 */
 func Delete(data []byte, keys ...string) []byte {
 	lk := len(keys)
@@ -751,6 +749,16 @@ func Delete(data []byte, keys ...string) []byte {
 		endOffset = startOffset + subEndOffset
 		tokEnd := tokenEnd(data[endOffset:])
 		tokStart := findTokenStart(data[:keyOffset], ","[0])
+
+		// Fuzz-generated or truncated input can leave endOffset+tokEnd
+		// past the end of data, which used to panic the whole process
+		// with 'index out of range' before any caller could recover
+		// (#274). Bail out and return the original buffer unchanged
+		// when the index is out of range - equivalent to 'nothing to
+		// delete here'.
+		if endOffset+tokEnd >= len(data) {
+			return data
+		}
 
 		if data[endOffset+tokEnd] == ","[0] {
 			endOffset += tokEnd + 1
@@ -797,13 +805,11 @@ func Delete(data []byte, keys ...string) []byte {
 }
 
 /*
-
 Set - Receives existing data structure, path to set, and data to set at that key.
 
 Returns:
 `value` - modified byte array
 `err` - On any parsing error
-
 */
 func Set(data []byte, setValue []byte, keys ...string) (value []byte, err error) {
 	// ensure keys are set


### PR DESCRIPTION
## What

Fixes #274.

`Delete`'s nested-key branch assumed that `endOffset+tokEnd` (the byte after the found value's closing token) always stayed inside the input buffer. Fuzz-generated or truncated input can leave the computed index one-past the buffer, and the subsequent `data[endOffset+tokEnd]` read panics with:

```
panic: runtime error: index out of range [9] with length 9
```

killing the whole process before any caller could recover - this is how Delete surfaces as a deadly signal under libFuzzer / oss-fuzz.

## Fix

Bail out early and return the original buffer unchanged when the next-byte index is out of range. That matches the correct no-op semantic: 'there is nothing after the match to remove', so the caller gets their input back, no panic, no partial delete. The happy path is unchanged.

## Verification

Locally on macOS, go 1.26.2:
- `gofmt -s -l parser.go`: clean
- `go vet ./...`: clean (the existing `bytes_unsafe_test.go:26 reflect.StringHeader` note is pre-existing and untouched by this PR)
- `go test -race -count=1 ./...`: pass

Closes #274