### PR TITLE
fix: don't panic on empty key when path enters an array

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -322,7 +322,7 @@ func searchKeys(data []byte, keys ...string) int {
 			}
 		case '[':
 			// If we want to get array element by index
-			if keyLevel == level && keys[level][0] == '[' {
+			if keyLevel == level && len(keys[level]) > 0 && keys[level][0] == '[' {
 				keyLen := len(keys[level])
 				// Note: keys[level][0] == '[' is guaranteed by the outer if-guard,
 				// so the former middle term `keys[level][0] != '['` was always false

--- a/parser_test.go
+++ b/parser_test.go
@@ -1171,6 +1171,18 @@ var getArrayTests = []GetTest{
 		data:    []string{`1`, `2`, `3`, `4`},
 	},
 	{
+		desc:    `array with single empty-string key returns not-found, not panic`,
+		json:    `[]`,
+		path:    []string{""},
+		isFound: false,
+	},
+	{
+		desc:    `truncated array with empty key returns not-found, not panic`,
+		json:    `[`,
+		path:    []string{""},
+		isFound: false,
+	},
+	{
 		desc:    `read array of objects`,
 		json:    `{"a": { "b":[{"x":1},{"x":2},{"x":3},{"x":4}]}}`,
 		path:    []string{"a", "b"},


### PR DESCRIPTION
**Description**: For a `Get` call like `jsonparser.Get([]byte("[]"), "")` the `searchKeys` `'['` case reached `keys[level][0] == '['` with an empty `keys[level]` and indexed into a zero-length string, panicking with `index out of range [0] with length 0`. The reproducer is exactly the one in #247:

```go
jsonparser.Get([]byte(`[]`), "")
jsonparser.Get([]byte(`[`), "")
```

Both used to panic where the object equivalents (`{}` and `{`) correctly return `KeyPathNotFoundError`. After this change they fall through to the same array-skip branch and surface `KeyPathNotFoundError` instead.

Two regression cases added to `getArrayTests`.

**Benchmark before change**: this is a guard on an exceptional input. The hot path is untouched and the new check is a length comparison on a string already in cache, so I didn't expect (or measure) a perceivable benchmark delta. Happy to run `make bench` here if you'd like the numbers.

Closes #247.
