### PR TITLE
Improve parseInt throughput for short numbers

### DIFF
--- a/bytes.go
+++ b/bytes.go
@@ -7,13 +7,34 @@ const maxUint64 = 1<<64 - 1
 
 // About 2x faster then strconv.ParseInt because it only supports base 10, which is enough for JSON
 func parseInt(bytes []byte) (v int64, ok bool, overflow bool) {
-	if len(bytes) == 0 {
+	l := len(bytes)
+	if l == 0 {
 		return 0, false, false
 	}
 
 	var neg bool = false
+	i := 0
 	if bytes[0] == '-' {
 		neg = true
+		i = 1
+	}
+
+	if l-i < 19 {
+		for ; i < l; i++ {
+			d := bytes[i] - '0'
+			if d > 9 {
+				return 0, false, false
+			}
+			v = 10*v + int64(d)
+		}
+
+		if neg {
+			return -v, true, false
+		}
+		return v, true, false
+	}
+
+	if neg {
 		bytes = bytes[1:]
 	}
 


### PR DESCRIPTION
This adds a fast path for `parseInt` when the numeric portion is shorter than
19 decimal digits. In that case the value cannot overflow `int64`, so the loop
only needs to validate digits and accumulate into the named `int64` return
value. Longer inputs continue through the existing `uint64` overflow-checked
path.

Validation:

```text
go test -count=1 ./...
```

```text
ok  	github.com/buger/jsonparser	0.163s
```

Benchmark command:

```text
go test -run '^$' -bench 'BenchmarkParseInt$' -benchmem -count=20 .
benchstat baseline-bench.txt after-bench.txt
```

Result on my machine (`darwin/arm64`, Apple M4, Go 1.25.1):

```text
            │ baseline-bench.txt │ after-bench.txt │
            │       sec/op       │     sec/op      vs base
ParseInt-10       3.129n ± 4%       2.163n ± 5%  -30.90% (p=0.000 n=20)

            │ baseline-bench.txt │ after-bench.txt │
            │        B/op        │      B/op       vs base
ParseInt-10       0.000 ± 0%        0.000 ± 0%    ~ (p=1.000 n=20)

            │ baseline-bench.txt │ after-bench.txt │
            │      allocs/op     │   allocs/op     vs base
ParseInt-10       0.000 ± 0%        0.000 ± 0%    ~ (p=1.000 n=20)
```

I also checked the final implementation against the previous implementation
with a temporary differential test over fixed edge cases and deterministic
random byte slices, including boundaries and malformed inputs.

I found the candidate direction while experimenting with Sleepy -
https://sleepy.run/mcp, then manually simplified and validated it before
submitting.
